### PR TITLE
Rename package references from firecrawl-mcp to mcp-server-firecrawl

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Big thanks to [@vrknetha](https://github.com/vrknetha), [@cawstudios](https://ca
 ### Running with npx
 
 ```bash
-env FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp
+env FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y mcp-server-firecrawl
 ```
 
 ### Manual Installation
 
 ```bash
-npm install -g firecrawl-mcp
+npm install -g mcp-server-firecrawl
 ```
 
 ### Running on Cursor
@@ -43,11 +43,11 @@ To configure FireCrawl MCP in Cursor:
 2. Go to Features > MCP Servers 
 3. Click "+ Add New MCP Server"
 4. Enter the following:
-   - Name: "firecrawl-mcp" (or your preferred name)
+   - Name: "mcp-server-firecrawl" (or your preferred name)
    - Type: "command"
-   - Command: `env FIRECRAWL_API_KEY=your-api-key npx -y firecrawl-mcp`
+   - Command: `env FIRECRAWL_API_KEY=your-api-key npx -y mcp-server-firecrawl`
 
-> If you are using Windows and are running into issues, try `cmd /c "set FIRECRAWL_API_KEY=your-api-key && npx -y firecrawl-mcp"`
+> If you are using Windows and are running into issues, try `cmd /c "set FIRECRAWL_API_KEY=your-api-key && npx -y mcp-server-firecrawl"`
 
 Replace `your-api-key` with your FireCrawl API key.
 
@@ -62,7 +62,7 @@ Add this to your `./codeium/windsurf/model_config.json`:
   "mcpServers": {
     "mcp-server-firecrawl": {
       "command": "npx",
-      "args": ["-y", "firecrawl-mcp"],
+      "args": ["-y", "mcp-server-firecrawl"],
       "env": {
         "FIRECRAWL_API_KEY": "YOUR_API_KEY_HERE"
       }
@@ -149,7 +149,7 @@ Add this to your `claude_desktop_config.json`:
   "mcpServers": {
     "mcp-server-firecrawl": {
       "command": "npx",
-      "args": ["-y", "firecrawl-mcp"],
+      "args": ["-y", "mcp-server-firecrawl"],
       "env": {
         "FIRECRAWL_API_KEY": "YOUR_API_KEY_HERE",
 


### PR DESCRIPTION
You should keep the code on Github and npmjs consistent, at least the README should be synchronized, otherwise many users may encounter installation issues.

