### PR TITLE
Feat: Add HTTP Streamable Server Transport Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,52 @@ env SSE_LOCAL=true FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp
 
 Use the url: http://localhost:3000/sse
 
+### Running with HTTP Streamable Mode
+
+To run the server using HTTP Streamable transport:
+
+```bash
+env HTTP_STREAMABLE_SERVER=true FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp
+```
+
+This will start the server on port 8080. Clients can connect to the MCP server using the endpoint:
+```
+POST http://localhost:8080/{apiKey}/mcp
+```
+
+For MCP client integration, use the following configuration:
+
+```javascript
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+// Create an MCP client
+const client = new Client();
+
+// Configure HTTP Streamable transport
+const transport = new StreamableHTTPClientTransport({
+  url: `http://localhost:8080/your-api-key/mcp`,
+});
+
+// Connect to the server
+await client.connect(transport);
+
+// List available tools
+const { tools } = await client.listTools();
+console.log('Available tools:', tools.map(t => t.name));
+
+// Call tool example
+const result = await client.callTool({
+  name: 'firecrawl_scrape',
+  arguments: {
+    url: 'https://example.com',
+    formats: ['markdown']
+  }
+});
+
+console.log('Scrape result:', result);
+```
+
 ### Installing via Smithery (Legacy)
 
 To install Firecrawl for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@mendableai/mcp-server-firecrawl):
@@ -182,12 +228,16 @@ Optionally, you can add it to a file called `.vscode/mcp.json` in your workspace
 
 #### Optional Configuration
 
-##### Retry Configuration
-
 - `FIRECRAWL_RETRY_MAX_ATTEMPTS`: Maximum number of retry attempts (default: 3)
 - `FIRECRAWL_RETRY_INITIAL_DELAY`: Initial delay in milliseconds before first retry (default: 1000)
 - `FIRECRAWL_RETRY_MAX_DELAY`: Maximum delay in milliseconds between retries (default: 10000)
 - `FIRECRAWL_RETRY_BACKOFF_FACTOR`: Exponential backoff multiplier (default: 2)
+
+##### Server Mode Configuration
+
+- `SSE_LOCAL`: Set to "true" to use Server-Sent Events (SSE) transport (default: false)
+- `HTTP_STREAMABLE_SERVER`: Set to "true" to use HTTP Streamable transport (default: false)
+- `CLOUD_SERVICE`: Set to "true" for cloud mode operation (default: false)
 
 ##### Credit Usage Monitoring
 
@@ -225,6 +275,18 @@ export FIRECRAWL_API_KEY=your-api-key  # If your instance requires auth
 # Custom retry configuration
 export FIRECRAWL_RETRY_MAX_ATTEMPTS=10
 export FIRECRAWL_RETRY_INITIAL_DELAY=500     # Start with faster retries
+```
+
+For HTTP Streamable server mode:
+
+```bash
+# Run in HTTP Streamable mode
+export HTTP_STREAMABLE_SERVER=true
+export FIRECRAWL_API_KEY=your-api-key
+export PORT=8080  # Optional: customize port (default: 8080)
+
+# Start the server
+npx -y firecrawl-mcp
 ```
 
 ### Usage with Claude Desktop

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "@mendable/firecrawl-js": "^1.19.0",
-    "@modelcontextprotocol/sdk": "^1.4.1",
+    "@modelcontextprotocol/sdk": "^1.11.1",
     "dotenv": "^16.4.7",
     "express": "^5.1.0",
     "shx": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.19.0
         version: 1.19.0(ws@8.18.1)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.4.1
-        version: 1.6.1
+        specifier: ^1.11.1
+        version: 1.11.1
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
@@ -360,8 +360,8 @@ packages:
   '@mendable/firecrawl-js@1.19.0':
     resolution: {integrity: sha512-T0mEBVFyOMQkxLjq7QdXxxtlPJl2tpcl+SpusLSo4rngn/Nv/drJv3krjlN+d1isrCz/PZ6xqU4Sf5LLvuIT2g==}
 
-  '@modelcontextprotocol/sdk@1.6.1':
-    resolution: {integrity: sha512-oxzMzYCkZHMntzuyerehK3fV6A2Kwh5BD6CGEJSVDU2QNEhfLOptf2X7esQgaHZXHZY0oHmMsOtIDLP71UJXgA==}
+  '@modelcontextprotocol/sdk@1.11.1':
+    resolution: {integrity: sha512-9LfmxKTb1v+vUS1/emSk1f5ePmTLkb9Le9AxOB5T0XM59EUumwcS45z05h7aiZx3GI0Bl7mjb3FMEglYj+acuQ==}
     engines: {node: '>=18'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -1595,8 +1595,8 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
 
-  pkce-challenge@4.1.0:
-    resolution: {integrity: sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==}
+  pkce-challenge@5.0.0:
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
@@ -2424,14 +2424,15 @@ snapshots:
       - debug
       - ws
 
-  '@modelcontextprotocol/sdk@1.6.1':
+  '@modelcontextprotocol/sdk@1.11.1':
     dependencies:
       content-type: 1.0.5
       cors: 2.8.5
+      cross-spawn: 7.0.6
       eventsource: 3.0.5
       express: 5.1.0
       express-rate-limit: 7.5.0(express@5.1.0)
-      pkce-challenge: 4.1.0
+      pkce-challenge: 5.0.0
       raw-body: 3.0.0
       zod: 3.24.2
       zod-to-json-schema: 3.24.3(zod@3.24.2)
@@ -3898,7 +3899,7 @@ snapshots:
 
   pirates@4.0.6: {}
 
-  pkce-challenge@4.1.0: {}
+  pkce-challenge@5.0.0: {}
 
   pkg-dir@4.2.0:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1369,7 +1369,7 @@ async function runHTTPStreamableServer() {
 
   const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
 
-  // 单一端点处理所有MCP请求
+  // A single endpoint handles all MCP requests.
   app.all('/:apiKey/mcp', async (req: Request, res: Response) => {
 
     try {


### PR DESCRIPTION

**Body:**

Hi team,

This PR introduces support for HTTP Streamable transport to the Firecrawl MCP server. This enhancement provides an alternative way for clients to connect and interact with the server, aligning with the latest specifications and offering more flexibility for integrations.

**Key Changes:**

*   Added a new `runHTTPStreamableServer()` function in `src/index.ts` to enable the HTTP Streamable server.
*   Updated `README.md` to include:
    *   Instructions on how to run the server in HTTP Streamable mode.
    *   An example MCP client configuration for connecting via HTTP Streamable transport.
    *   Relevant environment variable `HTTP_STREAMABLE_SERVER` and configuration examples.

This addition is in the spirit of open source and aims to enhance the capabilities and interoperability of the Firecrawl MCP server. We believe this will be a valuable addition for users looking for different transport options.

For more information on the Model Context Protocol and its specifications, please refer to the official documentation: [https://modelcontextprotocol.io/specification/2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26)

We hope this contribution is a welcome addition to the project and look forward to your feedback!

Best regards,

Dangoron
