### PR TITLE
Fixes #2165 - Add Context Limit Support for MCP

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -7,7 +7,7 @@ This document explains the versioning system for the Firecrawl MCP Server, which
 The server provides versioned endpoints to maintain backward compatibility while supporting the latest Firecrawl features:
 
 - **V1 (Legacy)**: Uses Firecrawl JS 1.29.3 with extended tools
-- **V2 (Current)**: Uses Firecrawl JS 3.1.0 with modern API
+- **V2 (Current)**: Uses Firecrawl JS 3.1.0 with modern API + content limiting
 
 ## Endpoints
 
@@ -64,6 +64,12 @@ Local services (stdio, SSE local, HTTP streamable) use the V2 implementation by 
 - Improved format handling
 - Better caching with `maxAge` defaults
 - Support for multiple search sources (web, images, news)
+- **NEW**: Content limiting for MCP compatibility
+  - `maxResponseLength` parameter to control response size
+  - `maxArrayItems` parameter to limit array results
+  - Intelligent content truncation that preserves structure
+  - Environment variable support for global limits
+  - Backward compatible (0 = no limit)
 
 ## Migration Guide
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.1.9",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firecrawl-mcp",
-      "version": "3.1.9",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "MCP server for Firecrawl web scraping integration. Supports both cloud and self-hosted instances. Features include web scraping, search, batch processing, structured data extraction, and LLM-powered content analysis.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

  Fixes #2165 - Adds a comprehensive content limiting mechanism to make Firecrawl MCP Server more compatible with MCP and other integrations that require predictable context sizes.

  ## Changes

  ### ✨ New Features

  - **Content Size Control**: Added `maxResponseLength` parameter to limit response size in characters
  - **Array Limiting**: Added `maxArrayItems` parameter to limit number of results in arrays
  - **Intelligent Truncation**: Content is truncated at natural boundaries (newlines, sentences, words) to preserve structure
  - **Environment Variables**: Global limits via `MCP_MAX_RESPONSE_LENGTH` and `MCP_MAX_ARRAY_ITEMS`
  - **Backward Compatibility**: All parameters are optional (0 = no limit)

  ### 🔧 Implementation Details

  - Updated all relevant endpoints: `scrape`, `search`, `extract`, `map`, `crawl`, `check_crawl_status`
  - Added smart response formatter that handles both array and content limiting
  - Truncation metadata is added to responses when limits are applied
  - JSON structure is preserved during limiting operations
  - Logging for configuration and truncation events

  ### 📋 Usage Examples

  ```json
  {
    "name": "firecrawl_scrape",
    "arguments": {
      "url": "https://example.com",
      "maxResponseLength": 50000
    }
  }
  ```

  ### Global limits via environment variables
  `export MCP_MAX_RESPONSE_LENGTH=100000`
  `export MCP_MAX_ARRAY_ITEMS=50`
  
  fixes https://github.com/firecrawl/firecrawl/issues/2165

