### PR TITLE
docs: add install instructions for Warp

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,27 @@ Replace `your-api-key` with your Firecrawl API key. If you don't have one yet, y
 
 After adding, refresh the MCP server list to see the new tools. The Composer Agent will automatically use Firecrawl MCP when appropriate, but you can explicitly request it by describing your web scraping needs. Access the Composer via Command+L (Mac), select "Agent" next to the submit button, and enter your query.
 
+### Running on Warp
+
+1. Open Warp Settings
+2. Go to AI > Manage MCP servers
+3. Click "+ Add"
+4. Enter the following code:
+
+```json
+{
+  "mcp-server-firecrawl": {
+    "command": "npx",
+    "args": ["-y", "firecrawl-mcp"],
+    "env": {
+      "FIRECRAWL_API_KEY": "YOUR_API_KEY"
+    }
+  }
+}
+```
+
+Alternatively, use the slash command `/add-mcp` in the Warp Agent prompt.
+
 ### Running on Windsurf
 
 Add this to your `./codeium/windsurf/model_config.json`:


### PR DESCRIPTION
Instructions for how to add Firecrawl MCP to Warp. 

<img width="767" height="324" alt="Screenshot 2025-10-07 at 02 23 53" src="https://github.com/user-attachments/assets/c9c77089-97db-410f-952b-2219151fa414" />
