### PR TITLE
fix: add missing lang and country params to search tool schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -569,6 +569,8 @@ The query also supports search operators, that you can use if needed to refine t
     limit: z.number().optional(),
     tbs: z.string().optional(),
     filter: z.string().optional(),
+    lang: z.string().optional(),
+    country: z.string().optional(),
     location: z.string().optional(),
     sources: z
       .array(z.object({ type: z.enum(['web', 'images', 'news']) }))


### PR DESCRIPTION
## Summary

- The `firecrawl_search` tool's description examples show `lang` and `country` parameters (`"lang": "en"`, `"country": "us"`), but these were missing from the Zod schema
- This causes Zod validation errors when LLMs follow the documented usage examples
- Both parameters are defined in the Firecrawl JS SDK's `SearchParams` interface (`lang?: string`, `country?: string`) and are supported by the Firecrawl API

## Details

The tool description (lines 546-564) includes this example:
```json
{
  "query": "latest AI research papers 2023",
  "limit": 5,
  "lang": "en",
  "country": "us",
  "sources": [{ "type": "web" }]
}
```

But the Zod schema only defined `query`, `limit`, `tbs`, `filter`, `location`, `sources`, `scrapeOptions`, and `enterprise` — missing `lang` and `country`. Any MCP client LLM that followed the example would get a validation error.

## Test plan

- [x] `npm run build` passes
- [x] Verified `lang` and `country` match the SDK's `SearchParams` interface
- [x] The execute handler uses `{ query, ...opts }` destructuring, so new params are automatically forwarded to `client.search()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)