### PR TITLE
fix: block private URLs in MCP tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import type { IncomingHttpHeaders } from 'http';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { registerMonitorTools } from './monitor.js';
+import { assertSafeExternalUrl, assertSafeExternalUrls } from './urlGuard.js';
 
 dotenv.config({ debug: false, quiet: true });
 
@@ -501,6 +502,7 @@ ${
       string,
       unknown
     >;
+    assertSafeExternalUrl(url);
     const client = getClient(session);
     const transformed = transformScrapeParams(options as Record<string, unknown>);
     const cleaned = removeEmptyTopLevel(transformed);
@@ -571,6 +573,7 @@ Map a website to discover all indexed URLs on the site.
       string,
       unknown
     >;
+    assertSafeExternalUrl(url);
     const client = getClient(session);
     const cleaned = removeEmptyTopLevel(options as Record<string, unknown>);
     log.info('Mapping URL', { url: String(url) });
@@ -984,6 +987,7 @@ server.addTool({
   }),
   execute: async (args, { session, log }) => {
     const { url, ...options } = args as Record<string, unknown>;
+    assertSafeExternalUrl(String(url));
     const client = getClient(session);
 
     const opts = { ...options } as Record<string, unknown>;
@@ -1097,6 +1101,7 @@ Extract structured information from web pages using LLM capabilities. Supports b
   ): Promise<string> => {
     const client = getClient(session);
     const a = args as Record<string, unknown>;
+    assertSafeExternalUrls((a.urls as string[]) || []);
     log.info('Extracting from URLs', {
       count: Array.isArray(a.urls) ? a.urls.length : 0,
     });

--- a/src/urlGuard.ts
+++ b/src/urlGuard.ts
@@ -1,0 +1,120 @@
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+function isPrivateNetworkAllowed(): boolean {
+  return TRUE_VALUES.has(
+    (process.env.FIRECRAWL_ALLOW_PRIVATE_NETWORKS || '').toLowerCase()
+  );
+}
+
+function parseIPv4(hostname: string): number[] | undefined {
+  const parts = hostname.split('.');
+  if (parts.length !== 4) return undefined;
+
+  const octets = parts.map((part) => {
+    if (!/^\d+$/.test(part)) return Number.NaN;
+    if (part.length > 1 && part.startsWith('0')) return Number.NaN;
+    return Number(part);
+  });
+
+  if (
+    octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+  ) {
+    return undefined;
+  }
+
+  return octets;
+}
+
+function isPrivateIPv4(hostname: string): boolean {
+  const octets = parseIPv4(hostname);
+  if (!octets) return false;
+
+  const [a, b] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+}
+
+function isPrivateIPv6(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === '::1' ||
+    normalized === '0:0:0:0:0:0:0:1' ||
+    normalized.startsWith('fe80:') ||
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd')
+  );
+}
+
+function mappedIPv4FromIPv6(hostname: string): string | undefined {
+  if (!hostname.toLowerCase().startsWith('::ffff:')) return undefined;
+
+  const suffix = hostname.slice('::ffff:'.length);
+  if (suffix.includes('.')) return suffix;
+
+  const hextets = suffix.split(':');
+  if (hextets.length !== 2) return undefined;
+
+  const values = hextets.map((hextet) => Number.parseInt(hextet, 16));
+  if (
+    values.some(
+      (value) => !Number.isInteger(value) || value < 0 || value > 0xffff
+    )
+  ) {
+    return undefined;
+  }
+
+  return [
+    values[0] >> 8,
+    values[0] & 0xff,
+    values[1] >> 8,
+    values[1] & 0xff,
+  ].join('.');
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^\[/, '').replace(/\]$/, '').replace(/\.$/, '');
+}
+
+export function isBlockedLocalUrl(rawUrl: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+
+  const hostname = normalizeHostname(parsed.hostname.toLowerCase());
+  if (!hostname) return false;
+
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) return true;
+
+  const mappedIPv4 = mappedIPv4FromIPv6(hostname);
+  if (mappedIPv4) return isPrivateIPv4(mappedIPv4);
+
+  return isPrivateIPv4(hostname) || isPrivateIPv6(hostname);
+}
+
+export function assertSafeExternalUrl(rawUrl: string, fieldName = 'url'): void {
+  if (isPrivateNetworkAllowed()) return;
+
+  if (isBlockedLocalUrl(rawUrl)) {
+    throw new Error(
+      `${fieldName} targets a local or private network address. Set FIRECRAWL_ALLOW_PRIVATE_NETWORKS=true only for trusted self-hosted deployments.`
+    );
+  }
+}
+
+export function assertSafeExternalUrls(
+  urls: string[],
+  fieldName = 'urls'
+): void {
+  for (const url of urls) {
+    assertSafeExternalUrl(url, fieldName);
+  }
+}

--- a/tests/urlGuard.test.mjs
+++ b/tests/urlGuard.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { describe, it, afterEach } from 'node:test';
+
+import {
+  assertSafeExternalUrl,
+  assertSafeExternalUrls,
+  isBlockedLocalUrl,
+} from '../dist/urlGuard.js';
+
+describe('urlGuard', () => {
+  const originalAllowPrivate = process.env.FIRECRAWL_ALLOW_PRIVATE_NETWORKS;
+
+  afterEach(() => {
+    if (originalAllowPrivate === undefined) {
+      delete process.env.FIRECRAWL_ALLOW_PRIVATE_NETWORKS;
+    } else {
+      process.env.FIRECRAWL_ALLOW_PRIVATE_NETWORKS = originalAllowPrivate;
+    }
+  });
+
+  for (const url of [
+    'http://localhost:3000',
+    'https://app.localhost/path',
+    'http://127.0.0.1:8080',
+    'http://10.1.2.3',
+    'http://172.16.0.10',
+    'http://172.31.255.255',
+    'http://192.168.1.2',
+    'http://169.254.169.254/latest/meta-data',
+    'http://[::1]/',
+    'http://[fe80::1]/',
+    'http://[fd12:3456::1]/',
+    'http://[::ffff:127.0.0.1]/',
+  ]) {
+    it(`blocks local/private URL ${url}`, () => {
+      assert.equal(isBlockedLocalUrl(url), true);
+      assert.throws(
+        () => assertSafeExternalUrl(url),
+        /local or private network/
+      );
+    });
+  }
+
+  for (const url of [
+    'https://firecrawl.dev',
+    'https://docs.firecrawl.dev/features/scrape',
+    'https://example.com/blog/*',
+    'http://8.8.8.8',
+  ]) {
+    it(`allows public URL ${url}`, () => {
+      assert.equal(isBlockedLocalUrl(url), false);
+      assert.doesNotThrow(() => assertSafeExternalUrl(url));
+    });
+  }
+
+  it('checks every URL in array inputs', () => {
+    assert.throws(
+      () =>
+        assertSafeExternalUrls(['https://firecrawl.dev', 'http://127.0.0.1']),
+      /local or private network/
+    );
+  });
+
+  it('allows private-network URLs when explicitly enabled', () => {
+    process.env.FIRECRAWL_ALLOW_PRIVATE_NETWORKS = 'true';
+
+    assert.doesNotThrow(() => assertSafeExternalUrl('http://127.0.0.1:3000'));
+  });
+});


### PR DESCRIPTION
## Summary
- add a URL guard that rejects localhost, private IPv4 ranges, link-local metadata IPs, loopback/link-local/unique-local IPv6, and IPv4-mapped private IPv6 targets by default
- apply the guard before forwarding scrape, map, crawl, and extract requests to Firecrawl
- allow trusted self-hosted/private-network deployments to opt in with FIRECRAWL_ALLOW_PRIVATE_NETWORKS=true

## Why
This addresses the SSRF/local-network risk raised in #210 and #194. Shape validation with z.string().url() still allows targets like localhost, 127.0.0.1, 169.254.169.254, and private LAN ranges, so an MCP client can accidentally or maliciously route a tool call toward local infrastructure.

## Verification
- npm run build
- node --test tests/urlGuard.test.mjs
- git diff --check

Note: I also tried the repo lint command, but a fresh install does not currently include the ESLint/@typescript-eslint dev dependencies required by .eslintrc.json, so lint could not be run locally without changing dependency metadata.