### PR TITLE
fix(stdio): null-guard authenticate so `FIRECRAWL_API_KEY` works again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [3.20.1] - 2026-05-28
+
+### Fixed
+
+- Fix stdio transport regression introduced in 3.18.0 where every tool call
+  failed with `Unauthorized: API key is required when not using a self-hosted
+  instance` even when `FIRECRAWL_API_KEY` was set. The OAuth refactor in 3.18.0
+  made the `authenticate` callback unconditionally read `request.headers`, but
+  `firecrawl-fastmcp` invokes `authenticate(undefined)` for stdio (there is no
+  HTTP request context). The resulting `TypeError` was swallowed by FastMCP,
+  leaving the session unauthenticated. Added a null guard so env-var
+  credentials (`FIRECRAWL_API_KEY` / `FIRECRAWL_OAUTH_TOKEN`) are honored on
+  stdio again.
+
 ## [3.19.1] - 2026-05-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.20.0",
+  "version": "3.20.1",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,10 +251,18 @@ const server = new FastMCP<SessionData>({
     },
     protectedResourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(),
   },
-  authenticate: async (request: {
+  authenticate: async (request?: {
     headers: IncomingHttpHeaders;
   }): Promise<SessionData> => {
-    const headerCred = await resolveCredentialFromHeaders(request.headers);
+    // FastMCP invokes `authenticate(undefined)` for the stdio transport
+    // because there is no HTTP request context. Without this null guard,
+    // accessing `request.headers` throws a TypeError, FastMCP silently
+    // swallows it, and every subsequent tool call fails with
+    // "Unauthorized: API key is required when not using a self-hosted
+    // instance" even though `FIRECRAWL_API_KEY` is set in env.
+    const headerCred = request?.headers
+      ? await resolveCredentialFromHeaders(request.headers)
+      : undefined;
     const envCred = resolveCredentialFromEnv();
 
     if (process.env.CLOUD_SERVICE === 'true') {

--- a/src/types/fastmcp.d.ts
+++ b/src/types/fastmcp.d.ts
@@ -32,7 +32,7 @@ declare module 'firecrawl-fastmcp' {
       version?: string;
       logger?: Logger;
       roots?: { enabled?: boolean };
-      authenticate?: (request: {
+      authenticate?: (request?: {
         headers: IncomingHttpHeaders;
       }) => Promise<Session> | Session;
       oauth?: {


### PR DESCRIPTION
## Summary

Fixes a regression in 3.18.0–3.20.0 where every stdio tool call fails with `Unauthorized: API key is required when not using a self-hosted instance`, even when `FIRECRAWL_API_KEY` is set. 3.17.0 was the last working release.

## Root cause

The OAuth refactor in 3.18.0 made `authenticate` read `request.headers` unconditionally. But `firecrawl-fastmcp@1.0.5` (bumped in the same release) calls `authenticate(undefined)` on stdio — there is no HTTP request. The resulting `TypeError` is swallowed by FastMCP, the session is left `undefined`, and every tool call lands in `getClient(undefined)` and throws the misleading "Unauthorized" message.

## Fix

Null-guard `request?.headers` so env-var credentials (`FIRECRAWL_API_KEY` / `FIRECRAWL_OAUTH_TOKEN`) are honored on stdio again. Cloud and HTTP-streaming paths are untouched.

- `src/index.ts` — null-guard in the `authenticate` callback
- `src/types/fastmcp.d.ts` — make `request` optional, matches `firecrawl-fastmcp@1.0.5` runtime
- `package.json` — bump to `3.20.1`
- `CHANGELOG.md` — `[3.20.1]` entry

## Verification

Ran the reporter's exact stdio repro against the local build with a deliberately fake key:

- **Before:** `Tool 'firecrawl_search' execution failed: Unauthorized: API key is required when not using a self-hosted instance` (local error, no network call)
- **After:** `Tool 'firecrawl_search' execution failed: Request failed with status code 401` (env-var key resolved, request reached `api.firecrawl.dev`; real key returns real results)

`npx tsc --noEmit` clean.

Credit to the issue reporter for the bisect and proposed fix sketch.

resolves #246 