### PR TITLE
feat(mcp): add redactPII option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.20.2] - 2026-06-01
+
+### Added
+
+- Added `redactPII` to scrape, parse, and nested scrape option schemas so MCP callers can request PII redaction without adding a `pii` format.
+
 ## [3.20.1] - 2026-05-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `redactPII` to scrape, parse, and nested scrape option schemas so MCP callers can request PII redaction without adding a `pii` format.
+- Added `redactPII` to scrape, parse, and nested scrape option schemas so MCP callers can request PII redaction with a single flag.
 
 ## [3.20.1] - 2026-05-28
 

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ Scrape content from a single URL with advanced options.
 ```
 
 **Branding format:** Extracts comprehensive brand identity (colors, fonts, typography, spacing, logo, UI components) for design analysis or style replication.
-**Privacy:** Set `redactPII: true` to return content with personally identifiable information redacted. You do not need to request the `pii` format for redaction.
+**Privacy:** Set `redactPII: true` to return content with personally identifiable information redacted.
 
 **Returns:**
 

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Scrape content from a single URL with advanced options.
 ```
 
 **Branding format:** Extracts comprehensive brand identity (colors, fonts, typography, spacing, logo, UI components) for design analysis or style replication.
+**Privacy:** Set `redactPII: true` to return content with personally identifiable information redacted. You do not need to request the `pii` format for redaction.
 
 **Returns:**
 
@@ -565,7 +566,8 @@ Search the web and optionally extract content from search results.
     "country": "us",
     "scrapeOptions": {
       "formats": ["markdown"],
-      "onlyMainContent": true
+      "onlyMainContent": true,
+      "redactPII": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.20.1",
+  "version": "3.20.2",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",

--- a/server.json
+++ b/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "firecrawl-mcp",
-      "version": "3.19.1",
+      "version": "3.20.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -490,6 +490,7 @@ const scrapeParamsSchema = z.object({
     })
     .optional(),
   onlyMainContent: z.boolean().optional(),
+  redactPII: z.boolean().optional(),
   includeTags: z.array(z.string()).optional(),
   excludeTags: z.array(z.string()).optional(),
   waitFor: z.number().optional(),
@@ -638,6 +639,7 @@ If JSON extraction returns empty, minimal, or just navigation content, the page 
 **Branding format:** Extracts comprehensive brand identity (colors, fonts, typography, spacing, logo, UI components) for design analysis or style replication.
 **Performance:** Add maxAge parameter for 500% faster scrapes using cached data.
 **Lockdown mode:** Set \`lockdown: true\` to serve the request only from the existing index/cache without any outbound network request. For air-gapped or compliance-constrained use where the request URL itself is considered sensitive. Errors on cache miss. Billed at 5 credits.
+**Privacy:** Set \`redactPII: true\` to return content with personally identifiable information redacted. You do not need to request the \`pii\` format for redaction.
 **Returns:** JSON structured data, markdown, branding profile, or other formats as specified.
 ${
   SAFE_MODE
@@ -1587,6 +1589,7 @@ if (process.env.CLOUD_SERVICE !== 'true') {
       })
       .optional(),
     onlyMainContent: z.boolean().optional(),
+    redactPII: z.boolean().optional(),
     includeTags: z.array(z.string()).optional(),
     excludeTags: z.array(z.string()).optional(),
     removeBase64Images: z.boolean().optional(),
@@ -1633,6 +1636,7 @@ This is the fastest and most reliable way to extract content from a document on 
 
 **Supported file types:** .html, .htm, .xhtml, .pdf, .docx, .doc, .odt, .rtf, .xlsx, .xls
 **Unsupported options:** actions, screenshot/branding/changeTracking formats, waitFor > 0, location, mobile, proxy values other than "auto" or "basic".
+**Privacy:** Set \`redactPII: true\` to return content with personally identifiable information redacted. You do not need to request the \`pii\` format for redaction.
 
 **CRITICAL - Format Selection (same rules as firecrawl_scrape):**
 When the user asks for SPECIFIC data points from a document, you MUST use JSON format with a schema. Only use markdown when the user needs the ENTIRE document content.

--- a/src/index.ts
+++ b/src/index.ts
@@ -639,7 +639,7 @@ If JSON extraction returns empty, minimal, or just navigation content, the page 
 **Branding format:** Extracts comprehensive brand identity (colors, fonts, typography, spacing, logo, UI components) for design analysis or style replication.
 **Performance:** Add maxAge parameter for 500% faster scrapes using cached data.
 **Lockdown mode:** Set \`lockdown: true\` to serve the request only from the existing index/cache without any outbound network request. For air-gapped or compliance-constrained use where the request URL itself is considered sensitive. Errors on cache miss. Billed at 5 credits.
-**Privacy:** Set \`redactPII: true\` to return content with personally identifiable information redacted. You do not need to request the \`pii\` format for redaction.
+**Privacy:** Set \`redactPII: true\` to return content with personally identifiable information redacted.
 **Returns:** JSON structured data, markdown, branding profile, or other formats as specified.
 ${
   SAFE_MODE
@@ -1636,7 +1636,7 @@ This is the fastest and most reliable way to extract content from a document on 
 
 **Supported file types:** .html, .htm, .xhtml, .pdf, .docx, .doc, .odt, .rtf, .xlsx, .xls
 **Unsupported options:** actions, screenshot/branding/changeTracking formats, waitFor > 0, location, mobile, proxy values other than "auto" or "basic".
-**Privacy:** Set \`redactPII: true\` to return content with personally identifiable information redacted. You do not need to request the \`pii\` format for redaction.
+**Privacy:** Set \`redactPII: true\` to return content with personally identifiable information redacted.
 
 **CRITICAL - Format Selection (same rules as firecrawl_scrape):**
 When the user asks for SPECIFIC data points from a document, you MUST use JSON format with a schema. Only use markdown when the user needs the ENTIRE document content.


### PR DESCRIPTION
## Summary

This change adds `redactPII` to the MCP scrape and parse option schemas, which also enables the flag inside nested scrape options for tools that reuse the shared scrape schema. It documents the new privacy option, bumps the MCP package version, and updates the npm package entry in the MCP server metadata.