### PR TITLE
Add mcp-customs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 </div>
 
 # Firecrawl MCP Server
-[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_97%2F100-brightgreen)](https://github.com/mcpcustoms/mcp-customs)
 
 A Model Context Protocol (MCP) server that brings [Firecrawl](https://github.com/firecrawl/firecrawl) to MCP-compatible AI agents — search, scrape, and interact with the live web for clean, agent-ready context.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_97%2F100-brightgreen)](https://mcpcustoms.github.io/?server=firecrawl-mcp-server)
+
 <div align="center">
   <a name="readme-top"></a>
   <img
@@ -5,8 +7,6 @@
     height="140"
   >
 </div>
-
-[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_97%2F100-brightgreen)](https://mcpcustoms.github.io/?server=firecrawl-mcp-server)
 
 # Firecrawl MCP Server
 [![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_97%2F100-brightgreen)](https://github.com/mcpcustoms/mcp-customs)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 A Model Context Protocol (MCP) server that brings [Firecrawl](https://github.com/firecrawl/firecrawl) to MCP-compatible AI agents — search, scrape, and interact with the live web for clean, agent-ready context.
 
 > Big thanks to [@vrknetha](https://github.com/vrknetha), [@knacklabs](https://www.knacklabs.ai) for the initial implementation!
+> [![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_97%2F100-brightgreen)](https://mcpcustoms.github.io/?server=firecrawl-mcp-server)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 </div>
 
 # Firecrawl MCP Server
+[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_97%2F100-brightgreen)](https://github.com/mcpcustoms/mcp-customs)
 
 A Model Context Protocol (MCP) server that brings [Firecrawl](https://github.com/firecrawl/firecrawl) to MCP-compatible AI agents — search, scrape, and interact with the live web for clean, agent-ready context.
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@
   >
 </div>
 
+[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_97%2F100-brightgreen)](https://mcpcustoms.github.io/?server=firecrawl-mcp-server)
+
 # Firecrawl MCP Server
 [![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_97%2F100-brightgreen)](https://github.com/mcpcustoms/mcp-customs)
 
 A Model Context Protocol (MCP) server that brings [Firecrawl](https://github.com/firecrawl/firecrawl) to MCP-compatible AI agents — search, scrape, and interact with the live web for clean, agent-ready context.
 
 > Big thanks to [@vrknetha](https://github.com/vrknetha), [@knacklabs](https://www.knacklabs.ai) for the initial implementation!
-> [![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_97%2F100-brightgreen)](https://mcpcustoms.github.io/?server=firecrawl-mcp-server)
+
 
 ## Features
 


### PR DESCRIPTION
Ran your server through mcp-customs (https://github.com/mcpcustoms/mcp-customs), a free offline scanner I built that checks MCP servers for common security risks before install. It came back clean — 97/100.

Wrote up the full methodology (and where the tool got things wrong on other servers) here: https://dev.to/mcpcustoms/we-scanned-12-popular-mcp-servers-the-most-interesting-finding-was-our-own-false-positives-kcf

Adding the badge is obviously optional — totally fine to close this if you'd rather not, no hard feelings either way.