### PR TITLE
docs(readme): document keyless hosted MCP free tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ A Model Context Protocol (MCP) server that brings [Firecrawl](https://github.com
 
 ## Installation
 
+### Hosted MCP (keyless free tier)
+
+Connect to the remote hosted server with no setup:
+
+```
+https://mcp.firecrawl.dev/v2/mcp
+```
+
+On the keyless free tier, `scrape`, `search`, and `interact` work without an API key (rate-limited). Other tools such as `crawl`, `map`, `agent`, and `extract` still need a key.
+
+Prefer an API key or OAuth whenever the human can sign up. It unlocks the full tool set and higher limits. With a key, use:
+
+```
+https://mcp.firecrawl.dev/{FIRECRAWL_API_KEY}/v2/mcp
+```
+
+See the [MCP server docs](https://docs.firecrawl.dev/mcp-server) and the [agent onboarding guide](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for setup details.
+
 ### Running with npx
 
 ```bash


### PR DESCRIPTION
## Why

The keyless hosted MCP endpoint at `https://mcp.firecrawl.dev/v2/mcp` already works (implemented in `src/index.ts`), but the README only documents the API-key path. New users have no way to discover that they can scrape, search, and interact without an API key. This aligns the README with the existing Firecrawl MCP docs.

## Summary

- Add a "Hosted MCP (keyless free tier)" section near Installation in `README.md`.
- Document the keyless remote URL where `scrape`, `search`, and `interact` work without an API key (rate-limited).
- Note that `crawl`, `map`, `agent`, `extract`, and other tools still need a key.
- Keep API key and OAuth as the preferred path (full tool set, higher limits) and keep the existing npx + `FIRECRAWL_API_KEY` examples as the primary flow.
- Link to https://docs.firecrawl.dev/mcp-server and https://www.firecrawl.dev/agent-onboarding/SKILL.md for setup details.

Docs-only change. No server behavior, tool implementation, or CHANGELOG changes.

## Test Plan

- Verified both linked docs with Firecrawl before editing.
- Confirmed the diff is minimal and limited to `README.md`.
- Grepped added lines to confirm no forbidden terms (credit counts, per-IP wording, rate-limit mechanics) and no new em dashes.
- Rendered the new section to confirm code blocks and links are well formed.
