### PR TITLE
chore: bump MCP package to 3.22.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.22.2",
+  "version": "3.22.3",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",

--- a/server.json
+++ b/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "firecrawl-mcp",
-      "version": "3.22.1",
+      "version": "3.22.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Follow-up to #304: bump the npm package version so the merged FastMCP migration can publish successfully.\n\nValidation:\n- pnpm install --frozen-lockfile\n- pnpm run build\n- pnpm run lint\n- pnpm exec tsc --noEmit\n- pnpm test\n- npm pack\n- npm view firecrawl-mcp@3.22.3 returns 404 before publish