### PR TITLE
Clarify scrape cache provenance guidance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1112,7 +1112,7 @@ If JSON extraction returns empty, minimal, or just navigation content, the page 
 }
 \`\`\`
 **Branding format:** Extracts comprehensive brand identity (colors, fonts, typography, spacing, logo, UI components) for design analysis or style replication.
-**Performance:** Add maxAge parameter for 500% faster scrapes using cached data.
+**Performance:** Use \`maxAge\` to allow lower-latency responses from recent cached data when freshness-sensitive work does not require a fresh fetch. Attested Firecrawl-index cache hits include \`metadata.cache\`; absence of that object is not a liveness signal.
 **Lockdown mode:** Set \`lockdown: true\` to serve the request only from the existing index/cache without any outbound network request. For air-gapped or compliance-constrained use where the request URL itself is considered sensitive. Errors on cache miss. Billed at 5 credits.
 **Privacy:** Set \`redactPII: true\` to return content with personally identifiable information redacted.
 **Returns:** JSON structured data, markdown, branding profile, or other formats as specified.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1018,7 +1018,6 @@ server.addTool({
   },
   description: `
 Scrape content from a single URL with advanced options.
-This is the most powerful, fastest and most reliable scraper tool, if available you should always default to using this tool for any web scraping needs.
 
 **Best for:** Single page content extraction, when you know exactly which page contains the information.
 **Not recommended for:** Multiple pages (call scrape multiple times or use crawl), unknown page location (use search).
@@ -1230,7 +1229,7 @@ server.addTool({
     destructiveHint: false, // Query-only; no destructive side effects on external entities.
   },
   description: `
-Search the web and optionally extract content from search results. This is the most powerful web search tool available, and if available you should always default to using this tool for any web search needs.
+Search the web and optionally extract content from search results.
 
 The query also supports search operators, that you can use if needed to refine the search:
 | Operator | Functionality | Examples |

--- a/src/legacy/index.md
+++ b/src/legacy/index.md
@@ -45,7 +45,7 @@ This is the most powerful, fastest and most reliable scraper tool, if available 
   }
 }
 \`\`\`
-**Performance:** Add maxAge parameter for 500% faster scrapes using cached data.
+**Performance:** Use `maxAge` to allow lower-latency responses from recent cached data when freshness-sensitive work does not require a fresh fetch. Attested Firecrawl-index cache hits include `metadata.cache`; absence of that object is not a liveness signal.
 **Returns:** Markdown, HTML, or other formats as specified.
 `,
   inputSchema: {
@@ -208,7 +208,7 @@ This is the most powerful, fastest and most reliable scraper tool, if available 
         type: 'number',
         default: 172800000,
         description:
-          'Maximum age in milliseconds for cached content. Use cached data if available and younger than maxAge, otherwise scrape fresh. Enables 500% faster scrapes for recently cached pages. Default: 172800000',
+          'Maximum age in milliseconds for cached content. Use cached data if available and younger than maxAge, otherwise scrape fresh. Can reduce latency for recently cached pages. Attested Firecrawl-index cache hits include metadata.cache; absence is not proof of a miss, fresh scrape, bypass, or source-page liveness. Default: 172800000',
       },
     },
     required: ['url'],

--- a/src/legacy/index.md
+++ b/src/legacy/index.md
@@ -28,7 +28,6 @@ const SCRAPE_TOOL: Tool = {
   name: 'firecrawl_scrape',
   description: `
 Scrape content from a single URL with advanced options. 
-This is the most powerful, fastest and most reliable scraper tool, if available you should always default to using this tool for any web scraping needs.
 
 **Best for:** Single page content extraction, when you know exactly which page contains the information.
 **Not recommended for:** Multiple pages (use batch_scrape), unknown page (use search), structured data (use extract).
@@ -492,7 +491,7 @@ Check the status of a crawl job.
 const SEARCH_TOOL: Tool = {
   name: 'firecrawl_search',
   description: `
-Search the web and optionally extract content from search results. This is the most powerful web search tool available, and if available you should always default to using this tool for any web search needs.
+Search the web and optionally extract content from search results.
 
 **Best for:** Finding specific information across multiple websites, when you don't know which website has the information; when you need the most relevant content for a query.
 **Not recommended for:** When you need to search the filesystem. When you already know which website to scrape (use scrape); when you need comprehensive coverage of a single website (use map or crawl.


### PR DESCRIPTION
## Summary
- update `firecrawl_scrape` tool prose to describe `maxAge` as a latency/freshness tradeoff, not a guaranteed speedup
- teach agents that attested cache hits include `metadata.cache`
- clarify that absence of cache provenance is not proof of miss/fresh/bypass/liveness
- remove coercive “most powerful / always default” routing claims from scrape and search tool descriptions
- mirror the same wording in legacy generated docs

## Root cause / behavior change
The MCP tool description was an agent-facing source of the old overclaim. Agents could learn that cache equals “500% faster” without learning how to inspect provenance or choose the right tool. The descriptions now teach the narrower cache contract and route by capability instead of superlatives.

## Validation
- `npm test` ✅ (build + 9 node tests)
- `npm run lint` ✅
- scoped grep confirms no targeted MCP speed superlatives or coercive default-routing claims remain ✅
- `git diff --check` ✅
- GitHub build check ✅

## Dependency
Can merge with or after the API PR; prose does not depend on a JS SDK release.
