### PR TITLE
feat(search): add highlights parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Search the web and optionally extract content from search results.
   "name": "firecrawl_search",
   "arguments": {
     "query": "latest AI research papers 2023",
+    "highlights": true,
     "limit": 5,
     "lang": "en",
     "country": "us",
@@ -443,6 +444,8 @@ Search the web and optionally extract content from search results.
   }
 }
 ```
+
+Set `highlights` to `true` to request query-relevant highlights or `false` to keep the original search snippets. Omit it to use the API's default behavior.
 
 **Returns:**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.22.3",
+  "version": "3.22.4",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",

--- a/server.json
+++ b/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "firecrawl-mcp",
-      "version": "3.22.3",
+      "version": "3.22.4",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1298,6 +1298,12 @@ The query also supports search operators, that you can use if needed to refine t
   parameters: z
     .object({
       query: z.string().min(1),
+      highlights: z
+        .boolean()
+        .optional()
+        .describe(
+          'Return query-relevant highlights for each search result. Set to false to keep the original search snippets.'
+        ),
       limit: z.number().optional(),
       tbs: z.string().optional(),
       filter: z.string().optional(),

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -319,6 +319,11 @@ test('HTTP cloud transport preserves Firecrawl OAuth and well-known routes', asy
   assert.ok(httpToolNames.includes('firecrawl_scrape'));
   assert.ok(httpToolNames.includes('firecrawl_search'));
   assert.ok(httpToolNames.includes('firecrawl_parse'));
+  const searchTool = toolsMessage.result.tools.find(
+    (tool) => tool.name === 'firecrawl_search'
+  );
+  assert.equal(searchTool.inputSchema.properties.highlights.type, 'boolean');
+  assert.equal('default' in searchTool.inputSchema.properties.highlights, false);
 
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
@@ -349,7 +354,7 @@ test('HTTP cloud transport calls Firecrawl API with authenticated session', asyn
       jsonrpc: '2.0',
       method: 'tools/call',
       params: {
-        arguments: { limit: 1, query: 'example domain' },
+        arguments: { highlights: false, limit: 1, query: 'example domain' },
         name: 'firecrawl_search',
       },
     }),
@@ -386,6 +391,7 @@ test('HTTP cloud transport calls Firecrawl API with authenticated session', asyn
   assert.equal(fakeApi.requests[0].url, '/v2/search');
   assert.equal(fakeApi.requests[0].headers.authorization, 'Bearer fc-http-test');
   assert.deepEqual(fakeApi.requests[0].body, {
+    highlights: false,
     limit: 1,
     origin: 'mcp-fastmcp',
     query: 'example domain',


### PR DESCRIPTION
## Summary

- expose an optional `highlights` boolean on `firecrawl_search`
- forward explicit `true` and `false` values while leaving omitted requests unchanged
- document the parameter and bump the package version to `3.22.4`

## Validation

- `npm run lint`
- `npm test`
