### PR TITLE
feat(search): add read-only search-only MCP surface at /v2/mcp-search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -29,3 +29,6 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Test
+        run: pnpm test

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -36,7 +36,7 @@ COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENV PORT=3000
-# Second in-process instance (search surface). Internal only — reached by nginx
+# Second in-process instance (search surface). Internal only, reached by nginx.
 # on localhost, never exposed directly.
 ENV FIRECRAWL_MCP_SEARCH_PORT=3001
 EXPOSE 8080

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -36,6 +36,9 @@ COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENV PORT=3000
+# Second in-process instance (search surface). Internal only — reached by nginx
+# on localhost, never exposed directly.
+ENV FIRECRAWL_MCP_SEARCH_PORT=3001
 EXPOSE 8080
 
 CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A read-only, search-only surface is also hosted at:
 https://mcp.firecrawl.dev/v2/mcp-search
 ```
 
-It exposes a fixed set of six read-only tools — `firecrawl_search` and the five `firecrawl_research_*` tools — and performs no page-content fetching. It has its own OAuth identity; the full endpoint above is unchanged. See [docs/search-profile.md](docs/search-profile.md) for the full contract.
+It exposes a fixed set of six read-only tools: `firecrawl_search` and the five `firecrawl_research_*` tools. It performs no page-content fetching and has its own OAuth identity; the full endpoint above is unchanged. See [docs/search-profile.md](docs/search-profile.md) for the full contract.
 
 ### Running with npx
 
@@ -225,12 +225,9 @@ Use **access** tokens (`fco_…`) only. Refresh tokens (`fcr_…`) must be excha
 
 #### Search-only surface (hosted)
 
-In hosted mode (`CLOUD_SERVICE=true`) a second in-process instance serves the [search-only endpoint](#search-only-endpoint) on its own port. It is controlled by:
+In hosted mode (`CLOUD_SERVICE=true`) a second in-process instance serves the [search-only endpoint](#search-only-endpoint). The bundled service has a fixed deployment contract: nginx routes `/v2/mcp-search` to the instance on local port `3001`, and the OAuth protected-resource identifier is `https://mcp.firecrawl.dev/v2/mcp-search`.
 
-- `FIRECRAWL_MCP_SEARCH_ENABLED` (default `true`): set to `false` to not start the search instance.
-- `FIRECRAWL_MCP_SEARCH_PORT` (default `3001`): local port the search instance listens on (internal; fronted by the reverse proxy).
-- `FIRECRAWL_MCP_SEARCH_ENDPOINT` (default `/v2/mcp-search`): the endpoint path it serves.
-- `FIRECRAWL_MCP_SEARCH_RESOURCE_URL` (default `https://mcp.firecrawl.dev/v2/mcp-search`): its OAuth protected-resource identifier.
+`FIRECRAWL_MCP_SEARCH_ENABLED` (default `true`) is the supported operational toggle; set it to `false` to prevent the search instance from starting. The Node process also accepts `FIRECRAWL_MCP_SEARCH_PORT`, `FIRECRAWL_MCP_SEARCH_ENDPOINT`, and `FIRECRAWL_MCP_SEARCH_RESOURCE_URL` for isolated tests. Those overrides do not reconfigure the bundled nginx routes or the authorization server allowlist and must not be used independently in the hosted deployment.
 
 The search instance requires authentication for every request (including `tools/list`) and rejects OAuth tokens whose audience does not match its own resource.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ https://mcp.firecrawl.dev/{FIRECRAWL_API_KEY}/v2/mcp
 
 See the [MCP server docs](https://docs.firecrawl.dev/mcp-server) and the [agent onboarding guide](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for setup details.
 
+#### Search-only endpoint
+
+A read-only, search-only surface is also hosted at:
+
+```
+https://mcp.firecrawl.dev/v2/mcp-search
+```
+
+It exposes a fixed set of six read-only tools — `firecrawl_search` and the five `firecrawl_research_*` tools — and performs no page-content fetching. It has its own OAuth identity; the full endpoint above is unchanged. See [docs/search-profile.md](docs/search-profile.md) for the full contract.
+
 ### Running with npx
 
 ```bash
@@ -212,6 +222,17 @@ Hosted Firecrawl can issue OAuth **access tokens** (`fco_…`) via the authoriza
 - **stdio:** Use `FIRECRAWL_OAUTH_TOKEN` for a static access token, or keep using `FIRECRAWL_API_KEY` for an API key.
 
 Use **access** tokens (`fco_…`) only. Refresh tokens (`fcr_…`) must be exchanged at the token endpoint, not passed to the scrape/search API.
+
+#### Search-only surface (hosted)
+
+In hosted mode (`CLOUD_SERVICE=true`) a second in-process instance serves the [search-only endpoint](#search-only-endpoint) on its own port. It is controlled by:
+
+- `FIRECRAWL_MCP_SEARCH_ENABLED` (default `true`): set to `false` to not start the search instance.
+- `FIRECRAWL_MCP_SEARCH_PORT` (default `3001`): local port the search instance listens on (internal; fronted by the reverse proxy).
+- `FIRECRAWL_MCP_SEARCH_ENDPOINT` (default `/v2/mcp-search`): the endpoint path it serves.
+- `FIRECRAWL_MCP_SEARCH_RESOURCE_URL` (default `https://mcp.firecrawl.dev/v2/mcp-search`): its OAuth protected-resource identifier.
+
+The search instance requires authentication for every request (including `tools/list`) and rejects OAuth tokens whose audience does not match its own resource.
 
 ### Configuration Examples
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -7,23 +7,6 @@ http {
   server {
     listen 8080;
 
-    # Search surface: served by the second in-process instance on :3001 at the
-    # literal /v2/mcp-search path. `^~` makes this prefix win over the
-    # /v(1|2)/(.*) regex below, and the path is proxied verbatim (no rewrite),
-    # so it reaches the instance exactly as /v2/mcp-search.
-    location ^~ /v2/mcp-search {
-      proxy_http_version 1.1;
-      proxy_request_buffering off;
-      proxy_buffering off;
-      proxy_set_header Connection "";
-      proxy_read_timeout 620s;
-      proxy_send_timeout 620s;
-      proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_pass http://app_search;
-    }
-
     # Path-scoped protected-resource metadata for the search surface. An exact
     # `=` match outranks the ^~ /.well-known/ prefix below, so the origin-level
     # document still routes to the full instance.
@@ -50,6 +33,43 @@ http {
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_pass http://app;
+    }
+
+    # Search surface, header-based: exactly /v2/mcp-search (or a subpath), served
+    # by the second instance on :3001. The (?:/|$) boundary keeps it from
+    # swallowing unrelated paths like /v2/mcp-searchXYZ. Placed before the
+    # generic /v(1|2)/(.*) regex so it wins (first matching regex wins). Proxied
+    # verbatim — the instance serves the /v2/mcp-search path directly.
+    location ~ ^/v2/mcp-search(?:/|$) {
+      proxy_http_version 1.1;
+      proxy_request_buffering off;
+      proxy_buffering off;
+      proxy_set_header Connection "";
+      proxy_read_timeout 620s;
+      proxy_send_timeout 620s;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_pass http://app_search;
+    }
+
+    # Search surface, key-in-path: /{apiKey}/v2/mcp-search. Mirrors the legacy
+    # key-bearing form for the full endpoint, but routes to the search instance
+    # and preserves the /v2/mcp-search path (only the key segment is stripped).
+    # Must precede the legacy /{apiKey}/v(1|2)/(.*) regex below.
+    location ~ ^/(?<apikey>[^/]+)/v2/mcp-search(?:/|$) {
+      proxy_set_header X-Firecrawl-API-Key $apikey;
+      proxy_http_version 1.1;
+      proxy_request_buffering off;
+      proxy_buffering off;
+      proxy_set_header Connection "";
+      proxy_read_timeout 620s;
+      proxy_send_timeout 620s;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      rewrite ^/[^/]+(/v2/mcp-search.*)$ $1 break;
+      proxy_pass http://app_search;
     }
 
     # Header-based with version: /v1|v2/{rest} (MUST COME BEFORE LEGACY)

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -39,7 +39,7 @@ http {
     # by the second instance on :3001. The (?:/|$) boundary keeps it from
     # swallowing unrelated paths like /v2/mcp-searchXYZ. Placed before the
     # generic /v(1|2)/(.*) regex so it wins (first matching regex wins). Proxied
-    # verbatim — the instance serves the /v2/mcp-search path directly.
+    # verbatim because the instance serves the /v2/mcp-search path directly.
     location ~ ^/v2/mcp-search(?:/|$) {
       proxy_http_version 1.1;
       proxy_request_buffering off;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,10 +1,41 @@
 events {}
 http {
   upstream app { server 127.0.0.1:3000; }
+  upstream app_search { server 127.0.0.1:3001; }
   gzip off;
 
   server {
     listen 8080;
+
+    # Search surface: served by the second in-process instance on :3001 at the
+    # literal /v2/mcp-search path. `^~` makes this prefix win over the
+    # /v(1|2)/(.*) regex below, and the path is proxied verbatim (no rewrite),
+    # so it reaches the instance exactly as /v2/mcp-search.
+    location ^~ /v2/mcp-search {
+      proxy_http_version 1.1;
+      proxy_request_buffering off;
+      proxy_buffering off;
+      proxy_set_header Connection "";
+      proxy_read_timeout 620s;
+      proxy_send_timeout 620s;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_pass http://app_search;
+    }
+
+    # Path-scoped protected-resource metadata for the search surface. An exact
+    # `=` match outranks the ^~ /.well-known/ prefix below, so the origin-level
+    # document still routes to the full instance.
+    location = /.well-known/oauth-protected-resource/v2/mcp-search {
+      proxy_buffering off;
+      proxy_read_timeout 30s;
+      proxy_send_timeout 30s;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_pass http://app_search;
+    }
 
     # OAuth discovery documents (RFC 8414 / RFC 9728) must reach the app with the
     # URI intact. `^~` makes this prefix win over the legacy /{apiKey}/{rest} regex

--- a/docs/search-profile.md
+++ b/docs/search-profile.md
@@ -49,9 +49,11 @@ tests — not by a runtime filter.
   document.
 - **Authenticated discovery.** Every request — including `tools/list` — requires
   a credential; the keyless free-tier fallback does not apply here.
-- **Audience enforcement.** OAuth access tokens are introspected; a token whose
-  audience does not name this resource is rejected with a 401. (Plain API keys
-  carry no audience and are unaffected.)
+- **Audience enforcement.** OAuth access tokens are introspected and must be
+  bound to this exact resource: a token whose audience names a different
+  resource — or that carries no audience binding at all — is rejected with a
+  401 (fail closed). Plain API keys carry no audience and are a direct
+  credential, so they are unaffected.
 
 The full surface's OAuth behavior is unchanged (origin-level metadata, no
 audience enforcement, keyless fallback intact).
@@ -59,9 +61,11 @@ audience enforcement, keyless fallback intact).
 ## Deployment
 
 Both instances start from the same image and process. The in-pod reverse proxy
-routes `/v2/mcp-search` and its metadata path to the search instance's local
-port; everything else routes to the full instance as before. No new domain and
-no infrastructure changes are required.
+routes `/v2/mcp-search` (and its key-in-path form `/{apiKey}/v2/mcp-search`)
+plus the metadata path to the search instance's local port; everything else
+routes to the full instance as before. If the search instance fails to bind its
+port, it is logged and skipped — the full instance is unaffected. No new domain
+and no infrastructure changes are required.
 
 Relevant configuration lives in `FIRECRAWL_MCP_SEARCH_*` environment variables
 (see the README) and the `/v2/mcp-search` routing in `docker/nginx.conf`.

--- a/docs/search-profile.md
+++ b/docs/search-profile.md
@@ -2,8 +2,8 @@
 
 The server runs two FastMCP instances in one process:
 
-- The **full** surface at `/v2/mcp` — the complete tool set, unchanged.
-- The **search** surface at `/v2/mcp-search` — a fixed, read-only subset.
+- The **full** surface at `/v2/mcp`, with the complete tool set unchanged.
+- The **search** surface at `/v2/mcp-search`, with a fixed, read-only subset.
 
 Only the request path selects the surface. There is no inspection of client
 identity, `User-Agent`, or `clientInfo`.
@@ -22,8 +22,8 @@ The search surface exposes exactly these six read-only tools and nothing else:
 | `firecrawl_research_search_github` | Search public repository history and readmes |
 
 Registration on this instance is filtered against that allowlist, so any tool
-outside the set — scrape, map, crawl, extract, agent, interact, parse, monitor,
-and the feedback tools — is never registered. Both `tools/list` and
+outside the set, including scrape, map, crawl, extract, agent, interact, parse,
+monitor, and the feedback tools, is never registered. Both `tools/list` and
 `tools/call` reflect only the six tools; calling anything else returns an
 unknown-tool error.
 
@@ -35,8 +35,8 @@ outbound `/v2/search` body from an explicit list of allowed fields
 (`query`, `limit`, `tbs`, `filter`, `location`, `sources`, `categories`,
 `highlights`, `enterprise`) plus `origin`. It never spreads raw arguments, so
 no request from this surface can ask the API to fetch third-party page content.
-This is enforced by the schema and body construction, and covered by contract
-tests — not by a runtime filter.
+The schema and body construction enforce this directly, and contract tests guard
+the behavior. No runtime filter is involved.
 
 ## OAuth
 
@@ -47,11 +47,11 @@ tests — not by a runtime filter.
   is served at `/.well-known/oauth-protected-resource/v2/mcp-search`. The 401
   challenge's `WWW-Authenticate: ... resource_metadata=...` points at that
   document.
-- **Authenticated discovery.** Every request — including `tools/list` — requires
+- **Authenticated discovery.** Every request, including `tools/list`, requires
   a credential; the keyless free-tier fallback does not apply here.
 - **Audience enforcement.** OAuth access tokens are introspected and must be
   bound to this exact resource: a token whose audience names a different
-  resource — or that carries no audience binding at all — is rejected with a
+  resource, or that carries no audience binding at all, is rejected with a
   401 (fail closed). Plain API keys carry no audience and are a direct
   credential, so they are unaffected.
 
@@ -64,11 +64,15 @@ Both instances start from the same image and process. The in-pod reverse proxy
 routes `/v2/mcp-search` (and its key-in-path form `/{apiKey}/v2/mcp-search`)
 plus the metadata path to the search instance's local port; everything else
 routes to the full instance as before. If the search instance fails to bind its
-port, it is logged and skipped — the full instance is unaffected. No new domain
+port, it is logged and skipped; the full instance is unaffected. No new domain
 and no infrastructure changes are required.
 
-Relevant configuration lives in `FIRECRAWL_MCP_SEARCH_*` environment variables
-(see the README) and the `/v2/mcp-search` routing in `docker/nginx.conf`.
+The bundled hosted deployment fixes the public path at `/v2/mcp-search`, the
+internal search port at `3001`, and the OAuth resource at
+`https://mcp.firecrawl.dev/v2/mcp-search`. `FIRECRAWL_MCP_SEARCH_ENABLED` is the
+supported operational toggle. Node-level overrides for the port, endpoint, and
+resource exist for isolated tests only; they do not update `docker/nginx.conf`
+or the authorization server allowlist.
 
 ## Tests
 

--- a/docs/search-profile.md
+++ b/docs/search-profile.md
@@ -1,0 +1,74 @@
+# Search-only MCP surface (`/v2/mcp-search`)
+
+The server runs two FastMCP instances in one process:
+
+- The **full** surface at `/v2/mcp` — the complete tool set, unchanged.
+- The **search** surface at `/v2/mcp-search` — a fixed, read-only subset.
+
+Only the request path selects the surface. There is no inspection of client
+identity, `User-Agent`, or `clientInfo`.
+
+## Tool contract
+
+The search surface exposes exactly these six read-only tools and nothing else:
+
+| Tool | Purpose |
+| --- | --- |
+| `firecrawl_search` | Ranked web / index search results |
+| `firecrawl_research_search_papers` | Semantic search over indexed research papers |
+| `firecrawl_research_inspect_paper` | Canonical metadata for one paper |
+| `firecrawl_research_related_papers` | Citation-graph expansion from anchor papers |
+| `firecrawl_research_read_paper` | Full-text passages from one paper |
+| `firecrawl_research_search_github` | Search public repository history and readmes |
+
+Registration on this instance is filtered against that allowlist, so any tool
+outside the set — scrape, map, crawl, extract, agent, interact, parse, monitor,
+and the feedback tools — is never registered. Both `tools/list` and
+`tools/call` reflect only the six tools; calling anything else returns an
+unknown-tool error.
+
+## No page-content fetching
+
+The search surface's `firecrawl_search` takes **no `scrapeOptions`**. Its input
+schema is strict (unknown fields are rejected), and its executor builds the
+outbound `/v2/search` body from an explicit list of allowed fields
+(`query`, `limit`, `tbs`, `filter`, `location`, `sources`, `categories`,
+`highlights`, `enterprise`) plus `origin`. It never spreads raw arguments, so
+no request from this surface can ask the API to fetch third-party page content.
+This is enforced by the schema and body construction, and covered by contract
+tests — not by a runtime filter.
+
+## OAuth
+
+- **Resource identity.** The surface advertises its own protected resource,
+  `https://mcp.firecrawl.dev/v2/mcp-search`, distinct from the full surface's
+  `https://mcp.firecrawl.dev/v2/mcp`.
+- **Path-scoped metadata (RFC 9728).** The protected-resource metadata document
+  is served at `/.well-known/oauth-protected-resource/v2/mcp-search`. The 401
+  challenge's `WWW-Authenticate: ... resource_metadata=...` points at that
+  document.
+- **Authenticated discovery.** Every request — including `tools/list` — requires
+  a credential; the keyless free-tier fallback does not apply here.
+- **Audience enforcement.** OAuth access tokens are introspected; a token whose
+  audience does not name this resource is rejected with a 401. (Plain API keys
+  carry no audience and are unaffected.)
+
+The full surface's OAuth behavior is unchanged (origin-level metadata, no
+audience enforcement, keyless fallback intact).
+
+## Deployment
+
+Both instances start from the same image and process. The in-pod reverse proxy
+routes `/v2/mcp-search` and its metadata path to the search instance's local
+port; everything else routes to the full instance as before. No new domain and
+no infrastructure changes are required.
+
+Relevant configuration lives in `FIRECRAWL_MCP_SEARCH_*` environment variables
+(see the README) and the `/v2/mcp-search` routing in `docker/nginx.conf`.
+
+## Tests
+
+`tests/mcp-search-profile.test.mjs` asserts the six-tool contract, unknown-tool
+rejection, `scrapeOptions` rejection, the clean outbound body, authenticated
+`tools/list`, the path-scoped metadata document, audience acceptance/rejection,
+and that the full surface is unaffected. It runs in CI via `pnpm test`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,8 @@ type ToolLogger = Pick<Logger, 'debug' | 'error' | 'info' | 'warn'>;
  * A server profile parameterizes how a FastMCP instance is constructed. Two
  * profiles run side by side in one process: the default `full` profile (the
  * complete tool surface) and the `search` profile (a fixed, read-only subset).
- * Only the request path decides which surface answers — never client identity.
+ * Only the request path decides which surface answers. Client identity is never
+ * inspected.
  */
 type ServerProfile = {
   id: 'full' | 'search';
@@ -299,7 +300,7 @@ async function authenticateRequest(
 
   // On surfaces that opt in, an OAuth access token must be bound to this exact
   // resource: reject tokens minted for a different resource AND tokens with no
-  // audience binding at all (fail closed — an unbound token must not unlock a
+  // audience binding at all (fail closed; an unbound token must not unlock a
   // resource-scoped surface). Plain API keys carry no audience and are a direct
   // credential, so they are unaffected.
   if (profile.enforceAudience && resolved?.viaOAuth) {
@@ -2741,7 +2742,7 @@ Add \`"parsers": ["pdf"]\` (optionally with \`pdfOptions.maxPages\`) when parsin
 
 // Search-surface variant of firecrawl_search. It takes no scrapeOptions and
 // builds the outbound /v2/search body from an explicit set of fields, so the
-// surface never asks the API to fetch page content — the omission is enforced
+// surface never asks the API to fetch page content. The omission is enforced
 // by the schema and the body construction, not a runtime filter.
 function registerMarketplaceSearchTool(
   registrar: ToolRegistrar,
@@ -2827,8 +2828,8 @@ The query supports search operators to refine results:
         excludeDomains
       );
 
-      // Build the outbound body from allowed fields only — never spread the raw
-      // arguments — so no scrape/content-fetch options can reach the API.
+      // Build the outbound body from allowed fields only. Never spread the raw
+      // arguments, so no scrape/content-fetch options can reach the API.
       const searchBody = {
         query: searchQuery,
         ...removeEmptyTopLevel({

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,6 +212,8 @@ type OAuthIntrospectionResponse = {
 type ResolvedCredential = {
   credential: string;
   aud?: string | string[];
+  /** True when the credential came from introspecting an OAuth access token. */
+  viaOAuth: boolean;
 };
 
 async function introspectOAuthAccessToken(
@@ -270,13 +272,13 @@ async function resolveCredentialFromHeaders(
 
   if (bearer && isFirecrawlOAuthAccessToken(bearer)) {
     const { apiKey, aud } = await introspectOAuthAccessToken(bearer);
-    return { credential: apiKey, aud };
+    return { credential: apiKey, aud, viaOAuth: true };
   }
   if (headerApiKey) {
-    return { credential: headerApiKey };
+    return { credential: headerApiKey, viaOAuth: false };
   }
   if (bearer) {
-    return { credential: bearer };
+    return { credential: bearer, viaOAuth: false };
   }
   return undefined;
 }
@@ -295,16 +297,15 @@ async function authenticateRequest(
     ? await resolveCredentialFromHeaders(request.headers)
     : undefined;
 
-  // Reject tokens minted for a different resource. Only surfaces that opt in
-  // enforce this: a token issued for another resource must not be replayed
-  // against a resource-scoped surface. Plain API keys carry no audience and
-  // are unaffected.
-  if (
-    profile.enforceAudience &&
-    resolved &&
-    !audienceMatchesResource(resolved.aud, profile.resourceUrl)
-  ) {
-    throw new Error('OAuth token audience does not match this resource');
+  // On surfaces that opt in, an OAuth access token must be bound to this exact
+  // resource: reject tokens minted for a different resource AND tokens with no
+  // audience binding at all (fail closed — an unbound token must not unlock a
+  // resource-scoped surface). Plain API keys carry no audience and are a direct
+  // credential, so they are unaffected.
+  if (profile.enforceAudience && resolved?.viaOAuth) {
+    if (!resolved.aud || !audienceMatchesResource(resolved.aud, profile.resourceUrl)) {
+      throw new Error('OAuth token audience does not match this resource');
+    }
   }
 
   const headerCred = resolved?.credential;
@@ -441,6 +442,46 @@ function buildSearchQueryWithDomains(
 
   return query;
 }
+
+// Parameter fields shared by both firecrawl_search surfaces. The full surface
+// adds `scrapeOptions` on top; the search surface uses these as-is (strict, no
+// scrapeOptions). Defining the field set once keeps the two surfaces from
+// drifting when a source type, category, or filter changes.
+const searchToolBaseFields = {
+  query: z.string().min(1),
+  highlights: z
+    .boolean()
+    .optional()
+    .describe(
+      'Return query-relevant highlights for each search result. Set to false to keep the original search snippets.'
+    ),
+  limit: z.number().optional(),
+  tbs: z.string().optional(),
+  filter: z.string().optional(),
+  location: z.string().optional(),
+  includeDomains: z.array(searchDomainSchema).optional(),
+  excludeDomains: z.array(searchDomainSchema).optional(),
+  sources: z
+    .array(z.object({ type: z.enum(['web', 'images', 'news']) }))
+    .optional(),
+  categories: z
+    .array(z.enum(['github', 'research', 'pdf']))
+    .optional()
+    .describe(
+      'Limit results to specific source types. `github` searches GitHub repositories, code, issues, and docs; `research` searches academic and research sources; `pdf` searches PDF results.'
+    ),
+  enterprise: z.array(z.enum(['default', 'anon', 'zdr'])).optional(),
+};
+
+// Both surfaces forbid specifying includeDomains and excludeDomains together.
+function searchDomainsAreExclusive(args: {
+  includeDomains?: string[];
+  excludeDomains?: string[];
+}): boolean {
+  return !(args.includeDomains?.length && args.excludeDomains?.length);
+}
+const SEARCH_DOMAINS_CONFLICT_MESSAGE =
+  'includeDomains and excludeDomains cannot both be specified';
 
 class ConsoleLogger implements Logger {
   private shouldLog =
@@ -1442,38 +1483,13 @@ The query also supports search operators, that you can use if needed to refine t
 `,
   parameters: z
     .object({
-      query: z.string().min(1),
-      highlights: z
-        .boolean()
-        .optional()
-        .describe(
-          'Return query-relevant highlights for each search result. Set to false to keep the original search snippets.'
-        ),
-      limit: z.number().optional(),
-      tbs: z.string().optional(),
-      filter: z.string().optional(),
-      location: z.string().optional(),
-      includeDomains: z.array(searchDomainSchema).optional(),
-      excludeDomains: z.array(searchDomainSchema).optional(),
-      sources: z
-        .array(z.object({ type: z.enum(['web', 'images', 'news']) }))
-        .optional(),
-      categories: z
-        .array(z.enum(['github', 'research', 'pdf']))
-        .optional()
-        .describe(
-          'Limit results to specific source types. `github` searches GitHub repositories, code, issues, and docs; `research` searches academic and research sources; `pdf` searches PDF results.'
-        ),
+      ...searchToolBaseFields,
       scrapeOptions: scrapeParamsSchema
         .omit({ url: true })
         .partial()
         .optional(),
-      enterprise: z.array(z.enum(['default', 'anon', 'zdr'])).optional(),
     })
-    .refine(
-      (args) => !(args.includeDomains?.length && args.excludeDomains?.length),
-      'includeDomains and excludeDomains cannot both be specified'
-    ),
+    .refine(searchDomainsAreExclusive, SEARCH_DOMAINS_CONFLICT_MESSAGE),
   execute: async (args: unknown, { session, log }): Promise<string> => {
     const { query, ...opts } = args as Record<string, unknown>;
 
@@ -2772,39 +2788,12 @@ The query supports search operators to refine results:
 **Returns:** A JSON envelope of the form \`{ success, data: { web?, images?, news? }, id, creditsUsed }\`. Each result array contains the ranked results for that source.
 `,
     parameters: z
-      .object({
-        query: z.string().min(1),
-        highlights: z
-          .boolean()
-          .optional()
-          .describe(
-            'Return query-relevant highlights for each search result. Set to false to keep the original search snippets.'
-          ),
-        limit: z.number().optional(),
-        tbs: z.string().optional(),
-        filter: z.string().optional(),
-        location: z.string().optional(),
-        includeDomains: z.array(searchDomainSchema).optional(),
-        excludeDomains: z.array(searchDomainSchema).optional(),
-        sources: z
-          .array(z.object({ type: z.enum(['web', 'images', 'news']) }))
-          .optional(),
-        categories: z
-          .array(z.enum(['github', 'research', 'pdf']))
-          .optional()
-          .describe(
-            'Limit results to specific source types. `github` searches GitHub repositories, code, issues, and docs; `research` searches academic and research sources; `pdf` searches PDF results.'
-          ),
-        enterprise: z.array(z.enum(['default', 'anon', 'zdr'])).optional(),
-      })
+      .object({ ...searchToolBaseFields })
       // Reject unknown fields (notably scrapeOptions): this surface exposes no
       // way to request page-content fetching, and an unexpected field is an
       // error rather than being silently dropped.
       .strict()
-      .refine(
-        (args) => !(args.includeDomains?.length && args.excludeDomains?.length),
-        'includeDomains and excludeDomains cannot both be specified'
-      ),
+      .refine(searchDomainsAreExclusive, SEARCH_DOMAINS_CONFLICT_MESSAGE),
     execute: async (args: unknown, { session, log }): Promise<string> => {
       const {
         query,
@@ -2921,13 +2910,24 @@ if (searchProfileEnabled) {
   registerResearchTools(searchRegistrar, getClient);
   registerMarketplaceSearchTool(searchRegistrar, getClient);
 
-  await searchServer.start({
-    transportType: 'httpStream',
-    httpStream: {
-      port: searchProfile.port,
-      host: HOST,
-      endpoint: searchProfile.endpoint,
-      stateless: true,
-    },
-  });
+  // Isolate the search instance from the already-serving full instance: if it
+  // fails to bind (port in use, etc.), log and carry on rather than let a
+  // top-level rejection exit the process and take the healthy full surface down.
+  try {
+    await searchServer.start({
+      transportType: 'httpStream',
+      httpStream: {
+        port: searchProfile.port,
+        host: HOST,
+        endpoint: searchProfile.endpoint,
+        stateless: true,
+      },
+    });
+  } catch (error) {
+    console.error(
+      `[search-profile] failed to start on port ${searchProfile.port}; ` +
+        'the full surface is unaffected',
+      error
+    );
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,35 @@ interface SessionData {
 
 type ToolLogger = Pick<Logger, 'debug' | 'error' | 'info' | 'warn'>;
 
+/**
+ * A server profile parameterizes how a FastMCP instance is constructed. Two
+ * profiles run side by side in one process: the default `full` profile (the
+ * complete tool surface) and the `search` profile (a fixed, read-only subset).
+ * Only the request path decides which surface answers — never client identity.
+ */
+type ServerProfile = {
+  id: 'full' | 'search';
+  /** OAuth protected-resource display name. */
+  resourceName: string;
+  /** Server-level instructions surfaced to clients. */
+  instructions: string;
+  /** OAuth protected-resource identifier for this surface. */
+  resourceUrl: string;
+  /** httpStream endpoint override (defaults to fastmcp's own default). */
+  endpoint?: `/${string}`;
+  /** TCP port this instance listens on. */
+  port: number;
+  /** When set, only these tool names may register on this instance. */
+  toolAllowlist?: Set<string>;
+  /** Reject OAuth tokens minted for a different resource. */
+  enforceAudience: boolean;
+  /** Allow the keyless free-tier fallback (no credential required). */
+  allowKeyless: boolean;
+};
+
+/** Registers a tool onto an instance; a subset of the FastMCP surface. */
+type ToolRegistrar = Pick<FastMCP<SessionData>, 'addTool'>;
+
 const authResultByRequest = Symbol('firecrawlMcpAuthResult');
 
 type MCPAuthRequest = {
@@ -79,6 +108,8 @@ function isHttpStreamingTransport(): boolean {
 
 const DEFAULT_OAUTH_ISSUER = 'https://www.firecrawl.dev';
 const DEFAULT_MCP_RESOURCE_URL = 'https://mcp.firecrawl.dev/v2/mcp';
+const DEFAULT_MCP_SEARCH_RESOURCE_URL = 'https://mcp.firecrawl.dev/v2/mcp-search';
+const DEFAULT_MCP_SEARCH_ENDPOINT = '/v2/mcp-search';
 
 function withoutTrailingSlash(value: string): string {
   return value.replace(/\/+$/, '');
@@ -97,18 +128,40 @@ function getMcpResourceUrl(): string {
   );
 }
 
-// PRM lives at the MCP origin per RFC 9728 (one PRM per resource). firecrawl-fastmcp
-// auto-serves it at the standard /.well-known/oauth-protected-resource path from the
-// protectedResource config, so the URL is fully derived from the MCP resource.
-function getOAuthProtectedResourceMetadataUrl(): string {
-  return `${new URL(getMcpResourceUrl()).origin}/.well-known/oauth-protected-resource`;
+function getSearchMcpResourceUrl(): string {
+  return (
+    normalizeHeader(process.env.FIRECRAWL_MCP_SEARCH_RESOURCE_URL) ??
+    DEFAULT_MCP_SEARCH_RESOURCE_URL
+  );
+}
+
+function getSearchMcpEndpoint(): `/${string}` {
+  const configured = normalizeHeader(process.env.FIRECRAWL_MCP_SEARCH_ENDPOINT);
+  if (configured && configured.startsWith('/')) {
+    return configured as `/${string}`;
+  }
+  return DEFAULT_MCP_SEARCH_ENDPOINT;
+}
+
+// PRM location per RFC 9728. firecrawl-fastmcp serves the document both at the
+// origin-level path and at `/.well-known/oauth-protected-resource${endpoint}`.
+// The full surface uses the origin-level document (unchanged); a path-scoped
+// surface advertises the document that sits under its own resource path, so a
+// single host can carry more than one protected resource.
+function getOAuthProtectedResourceMetadataUrl(profile: ServerProfile): string {
+  const resource = new URL(profile.resourceUrl);
+  const base = `${resource.origin}/.well-known/oauth-protected-resource`;
+  return profile.id === 'full' ? base : `${base}${resource.pathname}`;
 }
 
 function escapeWWWAuthenticateValue(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
-function createOAuthChallengeResponse(error: unknown): Response | undefined {
+function createOAuthChallengeResponse(
+  error: unknown,
+  profile: ServerProfile
+): Response | undefined {
   if (!isMcpOAuthEnabled()) {
     return undefined;
   }
@@ -116,7 +169,7 @@ function createOAuthChallengeResponse(error: unknown): Response | undefined {
   const errorMessage =
     error instanceof Error ? error.message : String(error || 'Unauthorized');
   const wwwAuthenticate = [
-    `resource_metadata="${escapeWWWAuthenticateValue(getOAuthProtectedResourceMetadataUrl())}"`,
+    `resource_metadata="${escapeWWWAuthenticateValue(getOAuthProtectedResourceMetadataUrl(profile))}"`,
     'error="invalid_token"',
     `error_description="${escapeWWWAuthenticateValue(errorMessage)}"`,
   ].join(', ');
@@ -151,9 +204,19 @@ function isMcpOAuthEnabled(): boolean {
 type OAuthIntrospectionResponse = {
   active?: boolean;
   api_key?: string;
+  /** Resource(s) the token was minted for (RFC 8707 / RFC 7662). */
+  aud?: string | string[];
 };
 
-async function introspectOAuthAccessToken(token: string): Promise<string> {
+/** The resolved Firecrawl credential plus the audience it was issued for. */
+type ResolvedCredential = {
+  credential: string;
+  aud?: string | string[];
+};
+
+async function introspectOAuthAccessToken(
+  token: string
+): Promise<{ apiKey: string; aud?: string | string[] }> {
   const introspectionSecret = getOAuthIntrospectionSecret();
   if (!introspectionSecret) {
     throw new Error('OAuth token introspection is not configured');
@@ -180,31 +243,47 @@ async function introspectOAuthAccessToken(token: string): Promise<string> {
     throw new Error('Invalid OAuth access token');
   }
 
-  return data.api_key;
+  return { apiKey: data.api_key, aud: data.aud };
+}
+
+/**
+ * True when `aud` is absent (nothing to check) or names `resourceUrl`. A token
+ * may carry one audience or a list; a trailing slash never changes identity.
+ */
+function audienceMatchesResource(
+  aud: string | string[] | undefined,
+  resourceUrl: string
+): boolean {
+  if (aud == null) return true;
+  const list = Array.isArray(aud) ? aud : [aud];
+  const target = withoutTrailingSlash(resourceUrl);
+  return list.some((entry) => withoutTrailingSlash(entry) === target);
 }
 
 async function resolveCredentialFromHeaders(
   headers: IncomingHttpHeaders
-): Promise<string | undefined> {
+): Promise<ResolvedCredential | undefined> {
   const bearer = extractBearerToken(headers);
   const headerApiKey = normalizeHeader(
     headers['x-firecrawl-api-key'] ?? headers['x-api-key']
   );
 
   if (bearer && isFirecrawlOAuthAccessToken(bearer)) {
-    return introspectOAuthAccessToken(bearer);
+    const { apiKey, aud } = await introspectOAuthAccessToken(bearer);
+    return { credential: apiKey, aud };
   }
   if (headerApiKey) {
-    return headerApiKey;
+    return { credential: headerApiKey };
   }
   if (bearer) {
-    return bearer;
+    return { credential: bearer };
   }
   return undefined;
 }
 
 async function authenticateRequest(
-  request?: MCPAuthRequest
+  request: MCPAuthRequest | undefined,
+  profile: ServerProfile
 ): Promise<SessionData> {
   // FastMCP invokes `authenticate(undefined)` for the stdio transport
   // because there is no HTTP request context. Without this null guard,
@@ -212,22 +291,35 @@ async function authenticateRequest(
   // swallows it, and every subsequent tool call fails with
   // "Unauthorized: API key is required when not using a self-hosted
   // instance" even though `FIRECRAWL_API_KEY` is set in env.
-  const headerCred = request?.headers
+  const resolved = request?.headers
     ? await resolveCredentialFromHeaders(request.headers)
     : undefined;
+
+  // Reject tokens minted for a different resource. Only surfaces that opt in
+  // enforce this: a token issued for another resource must not be replayed
+  // against a resource-scoped surface. Plain API keys carry no audience and
+  // are unaffected.
+  if (
+    profile.enforceAudience &&
+    resolved &&
+    !audienceMatchesResource(resolved.aud, profile.resourceUrl)
+  ) {
+    throw new Error('OAuth token audience does not match this resource');
+  }
+
+  const headerCred = resolved?.credential;
   const envCred = resolveCredentialFromEnv();
 
   if (process.env.CLOUD_SERVICE === 'true') {
     if (!headerCred) {
-      // Keyless free tier over the hosted MCP: serve it only when a forwarding
-      // secret is configured, we know the end-user's client IP (so the API can
-      // rate-limit per real IP, not the shared server IP), AND that IP still
-      // has free quota. If the IP is out of quota (or keyless is off), fall
-      // through to throw so FastMCP emits the OAuth 401 + WWW-Authenticate
-      // challenge — i.e. prompt the user to connect an account exactly when
-      // their free quota runs out.
+      // Keyless free tier over the hosted MCP: serve it only when the surface
+      // permits it, a forwarding secret is configured, we know the end-user's
+      // client IP (so the API can rate-limit per real IP, not the shared
+      // server IP), AND that IP still has free quota. Otherwise fall through
+      // to throw so FastMCP emits the OAuth 401 + WWW-Authenticate challenge.
       const clientIp = extractClientIp(request);
       if (
+        profile.allowKeyless &&
         process.env.KEYLESS_PROXY_SECRET &&
         clientIp &&
         (await keylessEligible(clientIp))
@@ -270,26 +362,33 @@ async function authenticateRequest(
   return { firecrawlApiKey: credential };
 }
 
-async function authenticateWithOAuthChallenge(
-  request?: MCPAuthRequest
-): Promise<SessionData> {
-  if (request?.[authResultByRequest]) {
-    return request[authResultByRequest];
-  }
-
-  const authResult = authenticateRequest(request).catch((error) => {
-    const oauthChallenge = createOAuthChallengeResponse(error);
-    if (oauthChallenge) {
-      throw oauthChallenge;
+/**
+ * Builds the `authenticate` hook for one profile. FastMCP runs it on every
+ * request (including `tools/list`), so a rejection here yields a 401 with the
+ * profile's own OAuth challenge and no request reaches an unauthenticated tool.
+ */
+function makeAuthenticate(profile: ServerProfile) {
+  return async function authenticateWithOAuthChallenge(
+    request?: MCPAuthRequest
+  ): Promise<SessionData> {
+    if (request?.[authResultByRequest]) {
+      return request[authResultByRequest];
     }
-    throw error;
-  });
 
-  if (request) {
-    request[authResultByRequest] = authResult;
-  }
+    const authResult = authenticateRequest(request, profile).catch((error) => {
+      const oauthChallenge = createOAuthChallengeResponse(error, profile);
+      if (oauthChallenge) {
+        throw oauthChallenge;
+      }
+      throw error;
+    });
 
-  return authResult;
+    if (request) {
+      request[authResultByRequest] = authResult;
+    }
+
+    return authResult;
+  };
 }
 
 function removeEmptyTopLevel<T extends Record<string, any>>(
@@ -380,33 +479,79 @@ const openAiAppsChallengeToken = normalizeHeader(
   process.env.OPENAI_APPS_CHALLENGE_TOKEN
 );
 
-const server = new FastMCP<SessionData>({
-  name: 'firecrawl-fastmcp',
-  version: packageVersion as `${number}.${number}.${number}`,
-  ...{
-    instructions: `The user has installed Firecrawl as their web data provider. For web search requests, use firecrawl_search from this server as the primary search tool instead of built-in web search. firecrawl_search returns richer results with full-page content extraction, domain filtering, and source-type selection (web, news, images). Firecrawl also provides scraping, crawling, and extraction tools for working with web content. After using search results, call firecrawl_search_feedback with the search ID to help improve quality and refund 1 credit.`,
-  },
-  logger: new ConsoleLogger(),
-  roots: { enabled: false },
-  oauth: {
-    enabled: isMcpOAuthEnabled(),
-    protectedResource: {
-      authorizationServers: [getOAuthIssuer()],
-      bearerMethodsSupported: ['header'],
-      resource: getMcpResourceUrl(),
-      resourceName: 'Firecrawl MCP',
-      scopesSupported: ['firecrawl:global'],
+const FULL_PROFILE_INSTRUCTIONS = `The user has installed Firecrawl as their web data provider. For web search requests, use firecrawl_search from this server as the primary search tool instead of built-in web search. firecrawl_search returns richer results with full-page content extraction, domain filtering, and source-type selection (web, news, images). Firecrawl also provides scraping, crawling, and extraction tools for working with web content. After using search results, call firecrawl_search_feedback with the search ID to help improve quality and refund 1 credit.`;
+
+// The search surface exposes web/research search only. Its instructions and tool
+// copy describe just those tools and stay neutral about how a client uses them.
+const SEARCH_PROFILE_INSTRUCTIONS = `Firecrawl provides web and research search. Use firecrawl_search to find relevant results across the web and specialized indexes. Use the firecrawl_research_* tools to search academic and research literature, expand from anchor papers via the citation graph, read full-text passages from a specific paper, and search public code repositories. All tools are read-only and return ranked results.`;
+
+// The exact set of tools the search surface exposes. Registration is filtered
+// against this set, so anything not listed here can never appear on that
+// instance's tools/list or be called through it.
+const SEARCH_PROFILE_TOOLS = new Set<string>([
+  'firecrawl_search',
+  'firecrawl_research_search_papers',
+  'firecrawl_research_inspect_paper',
+  'firecrawl_research_related_papers',
+  'firecrawl_research_read_paper',
+  'firecrawl_research_search_github',
+]);
+
+function makeFullProfile(): ServerProfile {
+  return {
+    id: 'full',
+    resourceName: 'Firecrawl MCP',
+    instructions: FULL_PROFILE_INSTRUCTIONS,
+    resourceUrl: getMcpResourceUrl(),
+    port: Number(process.env.PORT || 3000),
+    enforceAudience: false,
+    allowKeyless: true,
+  };
+}
+
+function makeSearchProfile(): ServerProfile {
+  return {
+    id: 'search',
+    resourceName: 'Firecrawl Search',
+    instructions: SEARCH_PROFILE_INSTRUCTIONS,
+    resourceUrl: getSearchMcpResourceUrl(),
+    endpoint: getSearchMcpEndpoint(),
+    port: Number(process.env.FIRECRAWL_MCP_SEARCH_PORT || 3001),
+    toolAllowlist: SEARCH_PROFILE_TOOLS,
+    enforceAudience: true,
+    allowKeyless: false,
+  };
+}
+
+function createServer(profile: ServerProfile): FastMCP<SessionData> {
+  return new FastMCP<SessionData>({
+    name: 'firecrawl-fastmcp',
+    version: packageVersion as `${number}.${number}.${number}`,
+    instructions: profile.instructions,
+    logger: new ConsoleLogger(),
+    roots: { enabled: false },
+    oauth: {
+      enabled: isMcpOAuthEnabled(),
+      protectedResource: {
+        authorizationServers: [getOAuthIssuer()],
+        bearerMethodsSupported: ['header'],
+        resource: profile.resourceUrl,
+        resourceName: profile.resourceName,
+        scopesSupported: ['firecrawl:global'],
+      },
     },
-  },
-  authenticate: authenticateWithOAuthChallenge,
-  // Lightweight health endpoint for LB checks
-  health: {
-    enabled: true,
-    message: 'ok',
-    path: '/health',
-    status: 200,
-  },
-});
+    authenticate: makeAuthenticate(profile),
+    // Lightweight health endpoint for LB checks
+    health: {
+      enabled: true,
+      message: 'ok',
+      path: '/health',
+      status: 200,
+    },
+  });
+}
+
+const server = createServer(makeFullProfile());
 
 if (openAiAppsChallengeToken) {
   server
@@ -2578,6 +2723,146 @@ Add \`"parsers": ["pdf"]\` (optionally with \`pdfOptions.maxPages\`) when parsin
   },
 });
 
+// Search-surface variant of firecrawl_search. It takes no scrapeOptions and
+// builds the outbound /v2/search body from an explicit set of fields, so the
+// surface never asks the API to fetch page content — the omission is enforced
+// by the schema and the body construction, not a runtime filter.
+function registerMarketplaceSearchTool(
+  registrar: ToolRegistrar,
+  getClientFn: typeof getClient
+): void {
+  registrar.addTool({
+    name: 'firecrawl_search',
+    annotations: {
+      title: 'Search the web',
+      readOnlyHint: true,
+      openWorldHint: true,
+      destructiveHint: false,
+    },
+    description: `
+Search the web and specialized indexes, returning ranked results.
+
+The query supports search operators to refine results:
+| Operator | Functionality | Examples |
+---|-|-|
+| \`"\` | Non-fuzzy matches a string of text | \`"Firecrawl"\`
+| \`-\` | Excludes certain keywords or negates other operators | \`-bad\`, \`-site:firecrawl.dev\`
+| \`site:\` | Only returns results from a specified website | \`site:firecrawl.dev\`
+| \`inurl:\` | Only returns results that include a word in the URL | \`inurl:firecrawl\`
+| \`intitle:\` | Only returns results that include a word in the title of the page | \`intitle:Firecrawl\`
+| \`related:\` | Only returns results that are related to a specific domain | \`related:firecrawl.dev\`
+
+**Best for:** Finding relevant results across many websites when you don't know which site has the information.
+**Sources:** web, images, news; default to web unless images or news are needed.
+**Categories:** Optional filter to limit result types: \`github\` (GitHub repositories, code, issues, and docs), \`research\` (academic and research sources), \`pdf\` (PDF results).
+**Domain filters:** Use includeDomains to restrict results to specific domains, or excludeDomains to remove domains. Do not use both in the same request. Domains must be hostnames only, without protocol or path.
+
+**Usage Example:**
+\`\`\`json
+{
+  "name": "firecrawl_search",
+  "arguments": {
+    "query": "top AI companies",
+    "limit": 5,
+    "includeDomains": ["example.com"],
+    "sources": [{ "type": "web" }]
+  }
+}
+\`\`\`
+**Returns:** A JSON envelope of the form \`{ success, data: { web?, images?, news? }, id, creditsUsed }\`. Each result array contains the ranked results for that source.
+`,
+    parameters: z
+      .object({
+        query: z.string().min(1),
+        highlights: z
+          .boolean()
+          .optional()
+          .describe(
+            'Return query-relevant highlights for each search result. Set to false to keep the original search snippets.'
+          ),
+        limit: z.number().optional(),
+        tbs: z.string().optional(),
+        filter: z.string().optional(),
+        location: z.string().optional(),
+        includeDomains: z.array(searchDomainSchema).optional(),
+        excludeDomains: z.array(searchDomainSchema).optional(),
+        sources: z
+          .array(z.object({ type: z.enum(['web', 'images', 'news']) }))
+          .optional(),
+        categories: z
+          .array(z.enum(['github', 'research', 'pdf']))
+          .optional()
+          .describe(
+            'Limit results to specific source types. `github` searches GitHub repositories, code, issues, and docs; `research` searches academic and research sources; `pdf` searches PDF results.'
+          ),
+        enterprise: z.array(z.enum(['default', 'anon', 'zdr'])).optional(),
+      })
+      // Reject unknown fields (notably scrapeOptions): this surface exposes no
+      // way to request page-content fetching, and an unexpected field is an
+      // error rather than being silently dropped.
+      .strict()
+      .refine(
+        (args) => !(args.includeDomains?.length && args.excludeDomains?.length),
+        'includeDomains and excludeDomains cannot both be specified'
+      ),
+    execute: async (args: unknown, { session, log }): Promise<string> => {
+      const {
+        query,
+        includeDomains,
+        excludeDomains,
+        limit,
+        tbs,
+        filter,
+        location,
+        sources,
+        categories,
+        highlights,
+        enterprise,
+      } = args as {
+        query: string;
+        includeDomains?: string[];
+        excludeDomains?: string[];
+        limit?: number;
+        tbs?: string;
+        filter?: string;
+        location?: string;
+        sources?: Array<{ type: string }>;
+        categories?: string[];
+        highlights?: boolean;
+        enterprise?: string[];
+      };
+
+      const searchQuery = buildSearchQueryWithDomains(
+        query,
+        includeDomains,
+        excludeDomains
+      );
+
+      // Build the outbound body from allowed fields only — never spread the raw
+      // arguments — so no scrape/content-fetch options can reach the API.
+      const searchBody = {
+        query: searchQuery,
+        ...removeEmptyTopLevel({
+          limit,
+          tbs,
+          filter,
+          location,
+          sources,
+          categories,
+          highlights,
+          enterprise,
+        }),
+        origin: ORIGIN,
+      };
+
+      log.info('Searching', { query: searchQuery });
+      const client = getClientFn(session);
+      const httpRes = await (client as any).http.post('/v2/search', searchBody);
+      return asText(httpRes?.data ?? {});
+    },
+  });
+}
+
 const PORT = Number(process.env.PORT || 3000);
 const HOST =
   process.env.CLOUD_SERVICE === 'true'
@@ -2610,3 +2895,39 @@ registerMonitorTools(server);
 registerResearchTools(server, getClient);
 
 await server.start(args);
+
+// Bring up the search surface as a second in-process instance on its own port.
+// The pod's nginx routes its public path here; the full surface above is
+// untouched. Only registered in the hosted profile and when not disabled.
+const searchProfileEnabled =
+  process.env.CLOUD_SERVICE === 'true' &&
+  process.env.FIRECRAWL_MCP_SEARCH_ENABLED !== 'false';
+
+if (searchProfileEnabled) {
+  const searchProfile = makeSearchProfile();
+  const searchServer = createServer(searchProfile);
+
+  // Fail-closed registrar: only allowlisted tool names ever register here.
+  const searchRegistrar: ToolRegistrar = {
+    addTool: ((tool: { name: string }) => {
+      if (searchProfile.toolAllowlist?.has(tool.name)) {
+        searchServer.addTool(
+          tool as Parameters<typeof searchServer.addTool>[0]
+        );
+      }
+    }) as FastMCP<SessionData>['addTool'],
+  };
+
+  registerResearchTools(searchRegistrar, getClient);
+  registerMarketplaceSearchTool(searchRegistrar, getClient);
+
+  await searchServer.start({
+    transportType: 'httpStream',
+    httpStream: {
+      port: searchProfile.port,
+      host: HOST,
+      endpoint: searchProfile.endpoint,
+      stateless: true,
+    },
+  });
+}

--- a/src/research.ts
+++ b/src/research.ts
@@ -229,7 +229,7 @@ function fmtGithub(results?: GitHubItem[]): string {
 }
 
 export function registerResearchTools(
-  server: FastMCP<SessionData>,
+  server: Pick<FastMCP<SessionData>, 'addTool'>,
   getClient: GetClient
 ): void {
   // --- search_papers ---

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -382,6 +382,30 @@ test('search surface rejects a token minted for a different resource', async (t)
   assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
 });
 
+test('search surface rejects an OAuth token with no audience binding', async (t) => {
+  // Introspection returns no `aud` (token was minted without a resource
+  // binding). A locked-down surface must fail closed rather than accept it.
+  const backend = await startFakeBackend({
+    apiKeyFromIntrospection: 'fc-introspected',
+    // introspectionAud omitted → introspect response has no aud field
+  });
+  t.after(() => backend.close());
+  const { searchPort } = await startHostedServer(t, {
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'introspect-secret',
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+  });
+
+  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 8,
+    method: 'tools/call',
+    params: { arguments: { query: 'x', limit: 1 }, name: 'firecrawl_search' },
+    headers: { authorization: 'Bearer fco_unbound_token' },
+  });
+  assert.equal(res.status, 401);
+  assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
+});
+
 test('search surface accepts a token minted for its own resource', async (t) => {
   const backend = await startFakeBackend({
     apiKeyFromIntrospection: 'fc-introspected',

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -1,0 +1,433 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import net from 'node:net';
+import test from 'node:test';
+import { setTimeout as delay } from 'node:timers/promises';
+
+// The fixed contract of the search surface. Nothing outside this set may ever
+// appear on its tools/list or be callable through it.
+const SEARCH_TOOLS = [
+  'firecrawl_search',
+  'firecrawl_research_search_papers',
+  'firecrawl_research_inspect_paper',
+  'firecrawl_research_related_papers',
+  'firecrawl_research_read_paper',
+  'firecrawl_research_search_github',
+];
+
+// A representative sample of the full-surface tools that must NOT leak here.
+const EXCLUDED_TOOLS = [
+  'firecrawl_scrape',
+  'firecrawl_map',
+  'firecrawl_crawl',
+  'firecrawl_check_crawl_status',
+  'firecrawl_extract',
+  'firecrawl_agent',
+  'firecrawl_interact',
+  'firecrawl_parse',
+  'firecrawl_monitor_create',
+  'firecrawl_search_feedback',
+  'firecrawl_feedback',
+];
+
+const SEARCH_ENDPOINT = '/v2/mcp-search';
+const SEARCH_RESOURCE = 'https://mcp.firecrawl.dev/v2/mcp-search';
+
+async function getFreePort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const { port } = server.address();
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return port;
+}
+
+async function waitForHealth(port, child) {
+  const url = `http://127.0.0.1:${port}/health`;
+  let lastError;
+  for (let i = 0; i < 60; i += 1) {
+    if (child.exitCode !== null) {
+      throw new Error(`server exited early with code ${child.exitCode}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return response;
+      lastError = new Error(`health returned ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(100);
+  }
+  throw lastError ?? new Error('server did not become healthy');
+}
+
+function parseSseJson(body) {
+  const dataLine = body
+    .split(/\r?\n/)
+    .find((line) => line.startsWith('data: '));
+  assert.ok(dataLine, `Missing SSE data line in body: ${body}`);
+  return JSON.parse(dataLine.slice('data: '.length));
+}
+
+function spawnServer(env) {
+  const child = spawn(process.execPath, ['dist/index.js'], {
+    env: { ...process.env, ...env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  child.stderr.setEncoding('utf8');
+  child.stdout.setEncoding('utf8');
+  return child;
+}
+
+async function stopChild(child) {
+  if (child.exitCode !== null) return;
+  child.kill('SIGTERM');
+  await Promise.race([
+    new Promise((resolve) => child.once('exit', resolve)),
+    delay(2_000).then(() => {
+      if (child.exitCode === null) child.kill('SIGKILL');
+    }),
+  ]);
+}
+
+// Fake origin standing in for both the Firecrawl API (/v2/search) and the OAuth
+// issuer (/api/oauth/introspect). Introspection echoes a configurable audience
+// so audience-enforcement can be exercised.
+async function startFakeBackend(options = {}) {
+  const {
+    apiKeyFromIntrospection = 'fc-from-introspection',
+    introspectionAud,
+  } = options;
+  const requests = [];
+  const server = createServer(async (req, res) => {
+    let raw = '';
+    req.setEncoding('utf8');
+    for await (const chunk of req) raw += chunk;
+
+    const contentType = req.headers['content-type'] ?? '';
+    let body;
+    if (raw && contentType.includes('application/json')) {
+      body = JSON.parse(raw);
+    } else if (raw && contentType.includes('application/x-www-form-urlencoded')) {
+      body = Object.fromEntries(new URLSearchParams(raw));
+    }
+    requests.push({ body, headers: req.headers, method: req.method, url: req.url });
+
+    if (req.method === 'POST' && req.url === '/api/oauth/introspect') {
+      const token = body?.token ?? '';
+      const active = token.startsWith('fco_') && !token.includes('invalid');
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify(
+          active
+            ? {
+                active: true,
+                api_key: apiKeyFromIntrospection,
+                ...(introspectionAud ? { aud: introspectionAud } : {}),
+              }
+            : { active: false }
+        )
+      );
+      return;
+    }
+
+    if (req.method === 'POST' && req.url === '/v2/search') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          creditsUsed: 1,
+          data: { web: [{ title: 'Example Domain', url: 'https://example.com/' }] },
+          id: '00000000-0000-4000-8000-000000000000',
+          success: true,
+        })
+      );
+      return;
+    }
+
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: `Unhandled ${req.method} ${req.url}` }));
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const { port } = server.address();
+  return {
+    requests,
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+// Spawn a hosted server with both the full and search instances running, and
+// wait until the search instance is healthy. Returns ports + a stderr accessor.
+async function startHostedServer(t, extraEnv = {}) {
+  const fullPort = await getFreePort();
+  const searchPort = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    HTTP_STREAMABLE_SERVER: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    PORT: String(fullPort),
+    FIRECRAWL_MCP_SEARCH_PORT: String(searchPort),
+    ...extraEnv,
+  });
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(searchPort, child);
+  return { child, fullPort, searchPort, getStderr: () => stderr };
+}
+
+function jsonRpc(port, endpoint, { id, method, params = {}, headers = {} }) {
+  return fetch(`http://127.0.0.1:${port}${endpoint}`, {
+    body: JSON.stringify({ id, jsonrpc: '2.0', method, params }),
+    headers: {
+      accept: 'application/json, text/event-stream',
+      'content-type': 'application/json',
+      ...headers,
+    },
+    method: 'POST',
+  });
+}
+
+async function listTools(port, endpoint, headers) {
+  const res = await jsonRpc(port, endpoint, {
+    id: 1,
+    method: 'tools/list',
+    headers,
+  });
+  assert.equal(res.status, 200, `tools/list returned ${res.status}`);
+  const message = parseSseJson(await res.text());
+  return message.result.tools.map((tool) => tool.name);
+}
+
+test('search surface lists exactly the six read-only tools', async (t) => {
+  const { searchPort, getStderr } = await startHostedServer(t);
+
+  const names = await listTools(searchPort, SEARCH_ENDPOINT, {
+    'x-api-key': 'fc-test',
+  });
+
+  assert.deepEqual([...names].sort(), [...SEARCH_TOOLS].sort());
+  for (const excluded of EXCLUDED_TOOLS) {
+    assert.equal(names.includes(excluded), false, `${excluded} must not appear`);
+  }
+  assert.equal(getStderr().includes('TypeError'), false, getStderr());
+});
+
+test('search surface does not expose an excluded tool', async (t) => {
+  const backend = await startFakeBackend();
+  t.after(() => backend.close());
+  const { searchPort } = await startHostedServer(t, {
+    FIRECRAWL_API_URL: backend.url,
+  });
+
+  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 2,
+    method: 'tools/call',
+    params: { arguments: { url: 'https://example.com' }, name: 'firecrawl_scrape' },
+    headers: { 'x-api-key': 'fc-test' },
+  });
+  // Unknown tool: either a JSON-RPC error or an error result, never a scrape.
+  const message = parseSseJson(await res.text());
+  const errored = Boolean(message.error) || message.result?.isError === true;
+  assert.equal(errored, true, JSON.stringify(message));
+  assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
+});
+
+test('search firecrawl_search rejects scrapeOptions and never fetches page content', async (t) => {
+  const backend = await startFakeBackend();
+  t.after(() => backend.close());
+  const { searchPort } = await startHostedServer(t, {
+    FIRECRAWL_API_URL: backend.url,
+  });
+
+  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 3,
+    method: 'tools/call',
+    params: {
+      arguments: {
+        query: 'example domain',
+        limit: 1,
+        scrapeOptions: { formats: ['markdown'] },
+      },
+      name: 'firecrawl_search',
+    },
+    headers: { 'x-api-key': 'fc-test' },
+  });
+  const message = parseSseJson(await res.text());
+  const errored = Boolean(message.error) || message.result?.isError === true;
+  assert.equal(errored, true, JSON.stringify(message));
+  // The rejected call must not have reached the API.
+  assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
+});
+
+test('search firecrawl_search sends a clean body built from allowed fields only', async (t) => {
+  const backend = await startFakeBackend();
+  t.after(() => backend.close());
+  const { searchPort } = await startHostedServer(t, {
+    FIRECRAWL_API_URL: backend.url,
+  });
+
+  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 4,
+    method: 'tools/call',
+    params: {
+      arguments: {
+        query: 'example domain',
+        limit: 1,
+        sources: [{ type: 'web' }],
+      },
+      name: 'firecrawl_search',
+    },
+    headers: { 'x-api-key': 'fc-search-key' },
+  });
+  assert.equal(res.status, 200);
+  const message = parseSseJson(await res.text());
+  assert.notEqual(message.result?.isError, true, JSON.stringify(message));
+
+  const searchCalls = backend.requests.filter((r) => r.url === '/v2/search');
+  assert.equal(searchCalls.length, 1);
+  assert.equal(searchCalls[0].headers.authorization, 'Bearer fc-search-key');
+  const sentBody = searchCalls[0].body;
+  assert.equal('scrapeOptions' in sentBody, false);
+  const allowedKeys = new Set([
+    'query',
+    'limit',
+    'tbs',
+    'filter',
+    'location',
+    'sources',
+    'categories',
+    'highlights',
+    'enterprise',
+    'origin',
+  ]);
+  for (const key of Object.keys(sentBody)) {
+    assert.equal(allowedKeys.has(key), true, `unexpected outbound field: ${key}`);
+  }
+  assert.deepEqual(sentBody, {
+    query: 'example domain',
+    limit: 1,
+    sources: [{ type: 'web' }],
+    origin: 'mcp-fastmcp',
+  });
+});
+
+test('search surface requires authentication for tools/list', async (t) => {
+  const { searchPort } = await startHostedServer(t);
+
+  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 5,
+    method: 'tools/list',
+  });
+  assert.equal(res.status, 401);
+  const wwwAuthenticate = res.headers.get('www-authenticate') ?? '';
+  assert.match(wwwAuthenticate, /^Bearer /);
+  assert.match(
+    wwwAuthenticate,
+    /resource_metadata="https:\/\/mcp\.firecrawl\.dev\/\.well-known\/oauth-protected-resource\/v2\/mcp-search"/
+  );
+  assert.match(wwwAuthenticate, /error="invalid_token"/);
+});
+
+test('search surface serves path-scoped protected-resource metadata', async (t) => {
+  const { searchPort } = await startHostedServer(t);
+
+  const res = await fetch(
+    `http://127.0.0.1:${searchPort}/.well-known/oauth-protected-resource${SEARCH_ENDPOINT}`
+  );
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), {
+    authorization_servers: ['https://www.firecrawl.dev'],
+    bearer_methods_supported: ['header'],
+    resource: SEARCH_RESOURCE,
+    resource_name: 'Firecrawl Search',
+    scopes_supported: ['firecrawl:global'],
+  });
+});
+
+test('search surface rejects a token minted for a different resource', async (t) => {
+  const backend = await startFakeBackend({
+    apiKeyFromIntrospection: 'fc-introspected',
+    introspectionAud: 'https://mcp.firecrawl.dev/v2/mcp', // the full resource, not search
+  });
+  t.after(() => backend.close());
+  const { searchPort } = await startHostedServer(t, {
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'introspect-secret',
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+  });
+
+  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 6,
+    method: 'tools/call',
+    params: { arguments: { query: 'x', limit: 1 }, name: 'firecrawl_search' },
+    headers: { authorization: 'Bearer fco_other_resource_token' },
+  });
+  assert.equal(res.status, 401);
+  assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
+});
+
+test('search surface accepts a token minted for its own resource', async (t) => {
+  const backend = await startFakeBackend({
+    apiKeyFromIntrospection: 'fc-introspected',
+    introspectionAud: SEARCH_RESOURCE,
+  });
+  t.after(() => backend.close());
+  const { searchPort } = await startHostedServer(t, {
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'introspect-secret',
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+  });
+
+  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 7,
+    method: 'tools/call',
+    params: { arguments: { query: 'x', limit: 1 }, name: 'firecrawl_search' },
+    headers: { authorization: 'Bearer fco_search_resource_token' },
+  });
+  assert.equal(res.status, 200);
+  const message = parseSseJson(await res.text());
+  assert.notEqual(message.result?.isError, true, JSON.stringify(message));
+  const searchCalls = backend.requests.filter((r) => r.url === '/v2/search');
+  assert.equal(searchCalls.length, 1);
+  assert.equal(searchCalls[0].headers.authorization, 'Bearer fc-introspected');
+});
+
+test('full surface still exposes its complete tool set alongside the search surface', async (t) => {
+  const { fullPort } = await startHostedServer(t);
+
+  // Full surface is reachable on its own port with all tools intact.
+  const names = await listTools(fullPort, '/v2/mcp', { 'x-api-key': 'fc-test' });
+  assert.ok(names.includes('firecrawl_scrape'));
+  assert.ok(names.includes('firecrawl_search'));
+  assert.ok(names.includes('firecrawl_parse'));
+  assert.ok(names.length > SEARCH_TOOLS.length);
+
+  // Its protected-resource metadata stays origin-level and unchanged.
+  const prm = await fetch(
+    `http://127.0.0.1:${fullPort}/.well-known/oauth-protected-resource`
+  );
+  assert.equal(prm.status, 200);
+  assert.deepEqual(await prm.json(), {
+    authorization_servers: ['https://www.firecrawl.dev'],
+    bearer_methods_supported: ['header'],
+    resource: 'https://mcp.firecrawl.dev/v2/mcp',
+    resource_name: 'Firecrawl MCP',
+    scopes_supported: ['firecrawl:global'],
+  });
+});


### PR DESCRIPTION
## Why

Provide a read-only, search-only MCP surface with a small, fixed tool set, no query-time page-content fetching, and its own OAuth identity. The existing endpoint exposes the full tool surface, so a separate endpoint is required to offer the narrower contract without changing existing clients.

## Summary

Adds a second in-process FastMCP instance at `/v2/mcp-search`, alongside the unchanged full surface at `/v2/mcp`. Only the request path selects the surface. Client identity is never inspected.

- **Profile factory.** Server construction is parameterized by a `ServerProfile` covering instructions, OAuth resource, tool allowlist, audience policy, and keyless policy. The full surface is constructed and started as before.
- **Fail-closed tool set.** The search surface registers exactly six read-only tools: `firecrawl_search` and the five `firecrawl_research_*` tools. Tools outside the allowlist are never registered, so both `tools/list` and `tools/call` expose only the approved contract.
- **Strict search variant.** The search-surface `firecrawl_search` has a strict schema with no `scrapeOptions` and constructs the outbound `/v2/search` body from an explicit set of allowed fields.
- **Path-aware OAuth.** The search surface has its own protected-resource metadata document and 401 challenge, requires authentication for every request, and rejects OAuth tokens without the matching audience. The full surface's OAuth behavior is unchanged.
- **Fixed hosted routing.** Bundled nginx routes the public path `/v2/mcp-search` to local port `3001`. The OAuth protected-resource identifier is `https://mcp.firecrawl.dev/v2/mcp-search`. `FIRECRAWL_MCP_SEARCH_ENABLED` is the supported operational toggle. Low-level Node overrides for the port, endpoint, and resource are used by isolated tests and do not reconfigure nginx or the authorization server allowlist.
- **Documentation.** The README and `docs/search-profile.md` describe the endpoint, exact tool contract, OAuth flow, and fixed hosted deployment contract.

## Test Plan

- `pnpm test`: 19/19 pass, including 10 search-profile contract tests and 9 existing smoke tests.
- `pnpm run lint`: pass.
- `git diff --check`: pass.
- Contract coverage includes the exact six-tool list, excluded-tool rejection, `scrapeOptions` rejection, clean outbound search body, authenticated `tools/list`, path-scoped protected-resource metadata, audience acceptance and rejection, and full-surface backward compatibility.

## Notes

- The search instance starts only in hosted mode and can be disabled with `FIRECRAWL_MCP_SEARCH_ENABLED=false`. Stdio mode is unaffected.
- End-to-end use depends on the authorization server allowlisting the search resource URL and returning `aud` during introspection. This does not change the existing endpoint.
