### PR TITLE
fix(mcp): harden legacy key-path compatibility

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -47,6 +47,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Firecrawl-Key-Transport "";
       proxy_pass http://app;
     }
 
@@ -60,6 +61,8 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+      # Only the dedicated legacy route below may set this internal marker.
+      proxy_set_header X-Firecrawl-Key-Transport "";
       proxy_pass http://app;
     }
 
@@ -76,6 +79,8 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+      # Do not accept a client-supplied legacy-path marker on the alias.
+      proxy_set_header X-Firecrawl-Key-Transport "";
       rewrite ^ /v2/mcp break;
       proxy_pass http://app;
     }
@@ -96,6 +101,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Firecrawl-Key-Transport "";
       proxy_pass http://__MCP_SEARCH_UPSTREAM__;
     }
 
@@ -123,6 +129,7 @@ http {
       proxy_read_timeout 620s;
       proxy_send_timeout 620s;
       proxy_set_header X-Firecrawl-API-Key $apikey;
+      proxy_set_header X-Firecrawl-Key-Transport path;
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
@@ -179,6 +186,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Firecrawl-Key-Transport "";
     }
 
     location /messages {
@@ -192,6 +200,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Firecrawl-Key-Transport "";
       proxy_pass http://app/messages;
     }
 
@@ -207,6 +216,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Firecrawl-Key-Transport "";
       proxy_pass http://app/sse;
     }
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -99,24 +99,16 @@ http {
       proxy_pass http://__MCP_SEARCH_UPSTREAM__;
     }
 
-    # Search surface, key-in-path: /{apiKey}/v2/mcp-search. Mirrors the legacy
-    # key-bearing form for the full endpoint, but routes to the search instance
-    # and preserves the /v2/mcp-search path (only the key segment is stripped).
+    # Search surface, key-in-path: /{apiKey}/v2/mcp-search. This form cannot
+    # authenticate an OAuth-only resource. Return a terminal migration response
+    # rather than forwarding to the companion (which is retired after cutover).
+    # Keep access logging disabled because the URI contains a credential.
     # Must precede the legacy /{apiKey}/v(1|2)/(.*) regex below.
     location ~ ^/(?<apikey>[^/]+)/v2/mcp-search(?:/|$) {
       access_log off;
-      proxy_set_header X-Firecrawl-API-Key $apikey;
-      proxy_http_version 1.1;
-      proxy_request_buffering off;
-      proxy_buffering off;
-      proxy_set_header Connection "";
-      proxy_read_timeout 620s;
-      proxy_send_timeout 620s;
-      proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      rewrite ^/[^/]+(/v2/mcp-search.*)$ $1 break;
-      proxy_pass http://__MCP_SEARCH_UPSTREAM__;
+      default_type application/json;
+      add_header Cache-Control "public, max-age=3600" always;
+      return 410 '{"error":"gone","message":"Key-in-path access to /v2/mcp-search has been removed. Use the OAuth-only Firecrawl search MCP resource.","migration_url":"https://docs.firecrawl.dev/mcp-server"}';
     }
 
     # Deprecated key-in-path MCP compatibility for the full identity. Never log

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,8 @@ interface SessionData extends CredentialSession {
   keylessClientIp?: string;
   authType?: 'api-key' | 'oauth' | 'env' | 'keyless' | 'none';
   credentialError?: 'CREDENTIAL_INVALID';
+  /** Internal nginx marker for the deprecated credential-in-path route. */
+  keyTransport?: 'path';
   teamId?: string;
   userId?: string;
   apiKeyId?: string;
@@ -120,6 +122,10 @@ function isFirecrawlOAuthAccessToken(token: string): boolean {
 
 function isFirecrawlApiKey(token: string): boolean {
   return token.startsWith('fc-');
+}
+
+function isLegacyKeyPathRequest(request: MCPAuthRequest | undefined): boolean {
+  return normalizeHeader(request?.headers?.['x-firecrawl-key-transport']) === 'path';
 }
 
 function requestShouldReceiveOAuthChallenge(
@@ -251,6 +257,19 @@ function createOAuthChallengeResponse(
   );
 }
 
+function createInvalidCredentialResponse(error: InvalidFirecrawlCredentialError): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'invalid_api_key',
+      error_description: error.message,
+    }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+      status: 401,
+    }
+  );
+}
+
 function getOAuthIntrospectionEndpoint(): string {
   return `${getOAuthIssuer()}/api/oauth/introspect`;
 }
@@ -293,6 +312,13 @@ type ResolvedCredential = {
   source?: 'api-key' | 'oauth' | 'env';
   metadata?: CredentialMetadata;
 };
+
+class InvalidFirecrawlCredentialError extends Error {
+  constructor() {
+    super('The supplied Firecrawl credential is invalid or revoked. Replace it and retry.');
+    this.name = 'InvalidFirecrawlCredentialError';
+  }
+}
 
 const MCP_GLOBAL_SCOPE = 'firecrawl:global';
 
@@ -469,6 +495,12 @@ async function authenticateRequest(
             `OAuth access token required for the Firecrawl MCP resource ${profile.endpoint}`
           );
         }
+        // The credential-in-path compatibility route is the only legacy shape
+        // that must fail at connection time. Header clients keep their existing
+        // recovery payload contract while this compatibility fix stays narrow.
+        if (isLegacyKeyPathRequest(request)) {
+          throw new InvalidFirecrawlCredentialError();
+        }
         return { authType: 'none', credentialError: 'CREDENTIAL_INVALID' };
       }
       if (profile.allowKeyless) {
@@ -485,6 +517,7 @@ async function authenticateRequest(
     const session: SessionData = {
       authType: resolved?.source === 'oauth' ? 'oauth' : 'api-key',
       firecrawlApiKey: headerCred,
+      ...(isLegacyKeyPathRequest(request) ? { keyTransport: 'path' as const } : {}),
       ...resolved?.metadata,
     };
     return managedCred ? setManagedOAuthApiKey(session, managedCred) : session;
@@ -577,6 +610,24 @@ function emitSearchCompanionAuthTelemetry(
   );
 }
 
+function emitLegacyKeyPathTelemetry(
+  profile: ServerProfile,
+  request: MCPAuthRequest | undefined,
+  outcome: 'accepted' | 'rejected',
+  session?: SessionData
+): void {
+  if (profile.id !== 'full' || !isLegacyKeyPathRequest(request)) return;
+  console.log(
+    '[MCP_LEGACY_KEY_PATH]',
+    JSON.stringify({
+      auth_type: session?.authType ?? 'none',
+      key_transport: 'path',
+      outcome,
+      resource: profile.resourceUrl,
+    })
+  );
+}
+
 /**
  * Builds the `authenticate` hook for one profile. FastMCP runs it on every
  * request (including `tools/list`), so a rejection here yields a 401 with the
@@ -598,10 +649,20 @@ function makeAuthenticate(profile: ServerProfile) {
           session.credentialError ? 'rejected' : 'accepted',
           session
         );
+        emitLegacyKeyPathTelemetry(
+          profile,
+          request,
+          session.credentialError ? 'rejected' : 'accepted',
+          session
+        );
         return session;
       })
       .catch((error) => {
         emitSearchCompanionAuthTelemetry(profile, request, 'rejected');
+        emitLegacyKeyPathTelemetry(profile, request, 'rejected');
+        if (error instanceof InvalidFirecrawlCredentialError) {
+          throw createInvalidCredentialResponse(error);
+        }
         if (error instanceof CredentialValidationUnavailableError) {
           throw new Response(
             JSON.stringify({

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1438,6 +1438,56 @@ test('account endpoint accepts legacy OAuth one way and delegates managed keys',
   assert.equal(stderr.includes('fco_legacy'), false);
 });
 
+test('legacy key-in-path telemetry is sanitized and does not leak the credential', async (t) => {
+  const backend = await startFakeFirecrawlBackend();
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const legacyCredential = 'fc-legacy-path-secret';
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  let stdout = '';
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const response = await fetch(`http://127.0.0.1:${port}/v2/mcp`, {
+    body: JSON.stringify({ id: 1, jsonrpc: '2.0', method: 'tools/list', params: {} }),
+    headers: {
+      accept: 'application/json, text/event-stream',
+      'content-type': 'application/json',
+      'x-firecrawl-api-key': legacyCredential,
+      'x-firecrawl-key-transport': 'path',
+    },
+    method: 'POST',
+  });
+  assert.equal(response.status, 200);
+  const legacyTools = parseSseJson(await response.text()).result.tools.map((tool) => tool.name);
+  assert.ok(legacyTools.includes('firecrawl_scrape'));
+  assert.ok(legacyTools.includes('firecrawl_search'));
+  assert.ok(legacyTools.includes('firecrawl_map'), legacyTools.join(', '));
+  await delay(25);
+
+  const telemetry = stdout
+    .split(/\r?\n/)
+    .find((line) => line.includes('[MCP_LEGACY_KEY_PATH]'));
+  assert.ok(telemetry, stdout);
+  assert.match(telemetry, /"key_transport":"path"/);
+  assert.match(telemetry, /"outcome":"accepted"/);
+  assert.match(telemetry, /"resource":"https:\/\/mcp\.firecrawl\.dev\/v2\/mcp"/);
+  assert.doesNotMatch(telemetry, new RegExp(legacyCredential));
+  assert.doesNotMatch(telemetry, /\bfc-[^\s"]+/);
+  assert.doesNotMatch(telemetry, /(?:\d{1,3}\.){3}\d{1,3}|::1/);
+});
+
 test('hosted profile selection fails closed for an unsupported endpoint', async () => {
   const child = spawnServer({
     CLOUD_SERVICE: 'true',
@@ -1487,6 +1537,10 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
     KEYLESS_PROXY_SECRET: 'delegation-secret',
     PORT: String(port),
   });
+  let stdout = '';
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
+  });
   t.after(() => stopChild(child));
   await waitForHealth(port, child);
 
@@ -1525,4 +1579,29 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
     3,
     'invalid-client-request-header-id',
   ]);
+
+  const invalidLegacyPath = await fetch(`http://127.0.0.1:${port}/v2/mcp`, {
+    body: JSON.stringify({ id: 4, jsonrpc: '2.0', method: 'tools/list', params: {} }),
+    headers: {
+      accept: 'application/json, text/event-stream',
+      'content-type': 'application/json',
+      'x-firecrawl-api-key': 'fc-invalid',
+      'x-firecrawl-key-transport': 'path',
+    },
+    method: 'POST',
+  });
+  assert.equal(invalidLegacyPath.status, 401);
+  assert.equal(invalidLegacyPath.headers.has('www-authenticate'), false);
+  assert.deepEqual(await invalidLegacyPath.json(), {
+    error: 'invalid_api_key',
+    error_description:
+      'The supplied Firecrawl credential is invalid or revoked. Replace it and retry.',
+  });
+  await delay(25);
+  const rejectedTelemetry = stdout
+    .split(/\r?\n/)
+    .find((line) => line.includes('[MCP_LEGACY_KEY_PATH]') && line.includes('\"outcome\":\"rejected\"'));
+  assert.ok(rejectedTelemetry, stdout);
+  assert.doesNotMatch(rejectedTelemetry, /\bfc-[^\s"]+/);
+  assert.doesNotMatch(rejectedTelemetry, /(?:\d{1,3}\.){3}\d{1,3}|::1/);
 });

--- a/tests/nginx-config.test.mjs
+++ b/tests/nginx-config.test.mjs
@@ -79,6 +79,28 @@ test('legacy MCP aliases stay bound to the full identity', () => {
   }
 });
 
+test('only the legacy full-MCP route can mark a request as credential-in-path', () => {
+  for (const route of [
+    'location ~ ^/v2/mcp-oauth/?$',
+    'location ~ ^/v2/mcp/?$',
+    'location = /mcp',
+    'location ~ ^/v2/mcp-search(?:/|$)',
+    'location /mcp',
+    'location /messages',
+    'location /sse',
+  ]) {
+    assert.match(
+      locationBody(route),
+      /proxy_set_header X-Firecrawl-Key-Transport "";/,
+      `${route} must clear a client-supplied legacy-path marker`
+    );
+  }
+  assert.match(
+    locationBody('location ~ ^/(?<apikey>[^/]+)/(?:v2/mcp|mcp)/?$'),
+    /proxy_set_header X-Firecrawl-Key-Transport path;/
+  );
+});
+
 test('search routes are rendered to a fixed upstream and readiness reaches Node', async () => {
   assert.match(config, /proxy_pass http:\/\/__MCP_SEARCH_UPSTREAM__;/);
   const entrypoint = await readFile(

--- a/tests/nginx-config.test.mjs
+++ b/tests/nginx-config.test.mjs
@@ -22,7 +22,6 @@ function locationBody(pattern) {
 
 test('key-bearing routes disable access logs before forwarding credentials', () => {
   for (const route of [
-    'location ~ ^/(?<apikey>[^/]+)/v2/mcp-search(?:/|$)',
     'location ~ ^/(?<apikey>[^/]+)/(?:v2/mcp|mcp)/?$',
     'location ~ ^/(?<apikey>[^/]+)/v(?:1|2)/(.*)$',
     'location ~ ^/(?<apikey>[^/]+)/(.*)$',
@@ -31,6 +30,20 @@ test('key-bearing routes disable access logs before forwarding credentials', () 
     assert.match(body, /access_log off;/);
     assert.match(body, /proxy_set_header X-Firecrawl-API-Key \$apikey;/);
   }
+});
+
+test('legacy key-in-path search returns a terminal migration response', () => {
+  const route = 'location ~ ^/(?<apikey>[^/]+)/v2/mcp-search(?:/|$)';
+  const start = config.indexOf(route);
+  assert.notEqual(start, -1, `missing nginx location: ${route}`);
+  const nextLocation = config.indexOf('\n    location ', start + route.length);
+  const body = config.slice(start, nextLocation === -1 ? config.length : nextLocation);
+
+  assert.match(body, /access_log off;/);
+  assert.match(body, /default_type application\/json;/);
+  assert.match(body, /return 410/);
+  assert.match(body, /"migration_url":"https:\/\/docs\.firecrawl\.dev\/mcp-server"/);
+  assert.doesNotMatch(body, /proxy_pass|X-Firecrawl-API-Key/);
 });
 
 test('specific MCP identities precede generic legacy regex routes', () => {


### PR DESCRIPTION
## Summary
- Keep the existing `/<API_KEY>/v2/mcp` compatibility route for the full MCP surface.
- Return an explicit, secret-free `401 invalid_api_key` result when that **legacy path** contains an invalid or revoked API key, instead of returning a successful empty tool list.
- Tag only accepted/rejected legacy-path sessions with a sanitized `[MCP_LEGACY_KEY_PATH]` event; it contains no key, URI, IP, or headers.
- Clear the internal marker on every other MCP-carrying nginx route, so a client cannot forge legacy-path usage.
- Return terminal `410 Gone` for `/<API_KEY>/v2/mcp-search`; search remains OAuth-only and this prevents a post-cutover 502.

## Compatibility boundary
- Direct `/v2/mcp` header and OAuth behavior is unchanged. Its existing structured credential-recovery payload is retained deliberately because installed header clients already rely on that MCP-level recovery contract; only the credential-in-path route needs a connection-time failure.
- No dashboard, generated config, or new-user path emits a credential-bearing URL.

## Verification
- `npm test` — 49 passing
- `npm run lint`
- nginx config syntax check
- Regression tests cover full-surface legacy path compatibility, explicit invalid legacy-path failure, direct-header recovery preservation, sanitized accepted/rejected telemetry, marker isolation across MCP routes, and key-path search 410.
