### PR TITLE
feat(mcp): accept the developer category on firecrawl_search

### DIFF
--- a/src/developer.ts
+++ b/src/developer.ts
@@ -1,0 +1,122 @@
+/**
+ * Firecrawl Developer search tool (experimental).
+ *
+ * Thin MCP wrapper over the `/v2/developer/search` endpoint (GitHub issues,
+ * merged pull requests, repository READMEs, and curated documentation sites).
+ *
+ * The installed `@mendable/firecrawl-js` predates a `developer` client, so we
+ * call the endpoint directly through the SDK's HTTP layer (auth + retries) via
+ * `client.http.get(...)`, mirroring how the research tools reach
+ * `/v2/search/research/*`.
+ */
+
+import { z } from 'zod';
+import type { FastMCP } from 'fastmcp';
+
+interface SessionData {
+  firecrawlApiKey?: string;
+  [key: string]: unknown;
+}
+
+/** Whatever `getClient` returns — we only touch its `http.get`. */
+type ClientLike = {
+  http: {
+    get: <T = unknown>(
+      endpoint: string,
+      headers?: Record<string, string>
+    ) => Promise<{ data: T; status: number }>;
+  };
+};
+
+// `getClient` returns a FirecrawlApp whose `http` member is private, so we type
+// the callback loosely and narrow to `ClientLike` at each call site.
+type GetClient = (session?: SessionData) => unknown;
+
+const BASE = '/v2/developer/search';
+const ORIGIN_HEADERS = { 'X-Origin': 'mcp-fastmcp' };
+
+// Cap the matched passages per result so a page of hits stays within the MCP
+// output-token limit. Sized like the research GitHub content cap: passages
+// carry the signal (repro steps, stack traces, API contracts) the agent needs.
+const MAX_PASSAGE_CHARS = 1200;
+
+interface DeveloperHit {
+  /** Stable result id, e.g. `issue:owner/repo#123` or `doc:<hash>`. */
+  id?: string;
+  /** Result kind: `issue`, `pull_request`, `readme`, or `doc`. */
+  type?: string;
+  url?: string;
+  title?: string;
+  /** Matched passages in markdown. */
+  passages?: { text?: string }[];
+}
+
+/**
+ * Render developer hits as `## [id] (type) title` / url / passages blocks —
+ * the same shape as the research formatters. Markdown passages keep their
+ * newlines so tables and code survive.
+ */
+function fmtDeveloper(results?: DeveloperHit[]): string {
+  if (!results || results.length === 0) return '(no results)';
+  return results
+    .map((r) => {
+      const kind = r.type ? ` (${r.type})` : '';
+      const lines = [`## [${r.id ?? '?'}]${kind} ${r.title ?? '(untitled)'}`];
+      if (r.url) lines.push(r.url);
+      const body = (r.passages ?? [])
+        .map((p) => p.text ?? '')
+        .join('\n---\n')
+        .trim();
+      lines.push(body ? body.slice(0, MAX_PASSAGE_CHARS) : '(no content)');
+      return lines.join('\n');
+    })
+    .join('\n\n');
+}
+
+export function registerDeveloperTools(
+  server: Pick<FastMCP<SessionData>, 'addTool'>,
+  getClient: GetClient
+): void {
+  // --- developer search ---
+  server.addTool({
+    name: 'firecrawl_developer_search',
+    annotations: {
+      title: 'Search developer sources',
+      readOnlyHint: true, // Semantic search over an indexed developer corpus; returns ranked results only.
+      openWorldHint: true, // Searches the Firecrawl developer index of public GitHub and documentation content.
+      destructiveHint: false, // Query-only; no writes to external sources or the developer index.
+    },
+    description: `
+For a developer question — code behaviour, a library or framework, an API contract, an error message, or a known bug — search an index built for coding agents. The index covers GitHub issues, merged pull requests, repository READMEs, and curated documentation sites.
+
+Returns ranked results with an ID, source type, URL, title, and the matched passages in markdown.
+`,
+    parameters: z.object({
+      query: z
+        .string()
+        .min(1)
+        .describe(
+          'Natural-language developer question or search phrase, including the library, error message, or API involved when relevant.'
+        ),
+      k: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('Number of ranked results to return (default 20).'),
+    }),
+    execute: async (args: unknown, { session }): Promise<string> => {
+      const { query, k } = args as { query: string; k?: number };
+      const params = new URLSearchParams();
+      params.append('query', query);
+      if (k != null) params.append('k', String(k));
+      const client = getClient(session) as ClientLike;
+      const res = await client.http.get<{ results?: DeveloperHit[] }>(
+        `${BASE}?${params.toString()}`,
+        ORIGIN_HEADERS
+      );
+      return fmtDeveloper(res.data?.results);
+    },
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -771,10 +771,10 @@ const searchToolBaseFields = {
     .array(z.object({ type: z.enum(['web', 'images', 'news']) }))
     .optional(),
   categories: z
-    .array(z.enum(['github', 'research', 'pdf']))
+    .array(z.enum(['github', 'research', 'pdf', 'developer']))
     .optional()
     .describe(
-      'Limit results to specific source types. `github` searches GitHub repositories, code, issues, and docs; `research` searches academic and research sources; `pdf` searches PDF results.'
+      'Limit results to specific source types. `github` searches GitHub repositories, code, issues, and docs; `research` searches academic and research sources; `pdf` searches PDF results; `developer` searches an index built for coding agents over GitHub issues, merged pull requests, repository READMEs, and curated documentation sites. `developer` adds a `data.developer` group of `{ url, title, description }` results, where `description` holds the matched passage; the other categories filter `data.web`.'
     ),
   enterprise: z.array(z.enum(['default', 'anon', 'zdr'])).optional(),
 };
@@ -831,7 +831,7 @@ const KEYLESS_PROFILE_INSTRUCTIONS = `Without authentication, this endpoint expo
 
 // The search surface exposes web/research search only. Its instructions and tool
 // copy describe just those tools and stay neutral about how a client uses them.
-const SEARCH_PROFILE_INSTRUCTIONS = `Firecrawl provides web and research search. Use firecrawl_search to find relevant results across the web and specialized indexes. Use the firecrawl_research_* tools to search academic and research literature, expand from anchor papers via the citation graph, read full-text passages from a specific paper, and search public code repositories. All tools are read-only and return ranked results.`;
+const SEARCH_PROFILE_INSTRUCTIONS = `Firecrawl provides web, developer, and research search. Use firecrawl_search to find relevant results across the web and specialized indexes. For a programming question, call firecrawl_search with categories: ["developer"] to search indexed GitHub issues, merged pull requests, READMEs, and documentation. Use the firecrawl_research_* tools to search academic and research literature, expand from anchor papers via the citation graph, read full-text passages from a specific paper, and search public code repositories. All tools are read-only and return ranked results.`;
 
 // The exact set of tools the search surface exposes. Registration is filtered
 // against this set, so anything not listed here can never appear on that
@@ -1850,7 +1850,9 @@ server.addTool({
     destructiveHint: false, // Query-only; no destructive side effects on external entities.
   },
   description: `
-Search web, news, or image sources and return ranked results. Operators include quoted phrases, \`-term\`, \`site:host\`, \`inurl:term\`, \`intitle:term\`, and \`related:host\`; the set is non-exhaustive. \`includeDomains\` and \`excludeDomains\` are mutually exclusive hostname filters; categories limit results to GitHub, research, or PDF sources.
+Search web, news, or image sources and return ranked results. Operators include quoted phrases, \`-term\`, \`site:host\`, \`inurl:term\`, \`intitle:term\`, and \`related:host\`; the set is non-exhaustive. \`includeDomains\` and \`excludeDomains\` are mutually exclusive hostname filters; categories limit results to GitHub, research, PDF, or developer sources.
+
+For a programming question, add \`categories: ["developer"]\`. It searches an index of GitHub issues, merged pull requests, repository READMEs, and curated documentation sites, and returns the hits in \`data.developer\` beside the web results.
 
 \`scrapeOptions\` can attach extracted page content. Returns source-type result groups, an \`id\` for optional search feedback, and usage metadata.
 `,
@@ -2830,7 +2832,9 @@ function registerMarketplaceSearchTool(
       destructiveHint: false,
     },
     description: `
-Search web and specialized indexes, returning ranked results. Operators include quoted phrases, \`-term\`, \`site:host\`, \`inurl:term\`, \`intitle:term\`, and \`related:host\`; the set is non-exhaustive. \`includeDomains\` and \`excludeDomains\` are mutually exclusive hostname filters; categories limit result types to \`github\`, \`research\`, or \`pdf\`.
+Search web and specialized indexes, returning ranked results. Operators include quoted phrases, \`-term\`, \`site:host\`, \`inurl:term\`, \`intitle:term\`, and \`related:host\`; the set is non-exhaustive. \`includeDomains\` and \`excludeDomains\` are mutually exclusive hostname filters; categories limit result types to \`github\`, \`research\`, \`pdf\`, or \`developer\`.
+
+For a programming question, add \`categories: ["developer"]\`. It searches an index of GitHub issues, merged pull requests, repository READMEs, and curated documentation sites, and returns the hits in \`data.developer\` beside the web results.
 
 Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`.
 `,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { createRequire } from 'node:module';
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { z } from 'zod';
+import { registerDeveloperTools } from './developer';
 import { extractSingleTrustedClientIp } from './keyless-client-ip';
 import { registerMonitorTools } from './monitor';
 import { registerResearchTools } from './research';
@@ -831,13 +832,14 @@ const KEYLESS_PROFILE_INSTRUCTIONS = `Without authentication, this endpoint expo
 
 // The search surface exposes web/research search only. Its instructions and tool
 // copy describe just those tools and stay neutral about how a client uses them.
-const SEARCH_PROFILE_INSTRUCTIONS = `Firecrawl provides web, developer, and research search. Use firecrawl_search to find relevant results across the web and specialized indexes. For a programming question, call firecrawl_search with categories: ["developer"] to search indexed GitHub issues, merged pull requests, READMEs, and documentation. Use the firecrawl_research_* tools to search academic and research literature, expand from anchor papers via the citation graph, read full-text passages from a specific paper, and search public code repositories. All tools are read-only and return ranked results.`;
+const SEARCH_PROFILE_INSTRUCTIONS = `Firecrawl provides web, developer, and research search. Use firecrawl_search to find relevant results across the web and specialized indexes. For a programming question, call firecrawl_developer_search — or firecrawl_search with categories: ["developer"] — to search indexed GitHub issues, merged pull requests, READMEs, and documentation. Use the firecrawl_research_* tools to search academic and research literature, expand from anchor papers via the citation graph, read full-text passages from a specific paper, and search public code repositories. All tools are read-only and return ranked results.`;
 
 // The exact set of tools the search surface exposes. Registration is filtered
 // against this set, so anything not listed here can never appear on that
 // instance's tools/list or be called through it.
 const SEARCH_PROFILE_TOOLS = new Set<string>([
   'firecrawl_search',
+  'firecrawl_developer_search',
   'firecrawl_research_search_papers',
   'firecrawl_research_inspect_paper',
   'firecrawl_research_related_papers',
@@ -2934,6 +2936,7 @@ if (
 
 registerMonitorTools(server);
 registerResearchTools(server, getClient);
+registerDeveloperTools(server, getClient);
 
 if (primaryProfile.id === 'search') {
   // The strict marketplace search tool intentionally replaces the full
@@ -2975,6 +2978,7 @@ if (searchProfileEnabled) {
   };
 
   registerResearchTools(searchRegistrar, getClient);
+  registerDeveloperTools(searchRegistrar, getClient);
   registerMarketplaceSearchTool(searchRegistrar, getClient);
 
   // Isolate the search instance from the already-serving full instance: if it

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -149,11 +149,31 @@ async function startFakeBackend(options = {}) {
     }
 
     if (req.method === 'POST' && req.url === '/v2/search') {
+      // The developer category is an extra arm: the API returns its hits in a
+      // `data.developer` group beside the web results.
+      const wantsDeveloper = (body?.categories ?? []).some((category) =>
+        typeof category === 'string'
+          ? category === 'developer'
+          : category?.type === 'developer'
+      );
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(
         JSON.stringify({
           creditsUsed: 1,
-          data: { web: [{ title: 'Example Domain', url: 'https://example.com/' }] },
+          data: {
+            web: [{ title: 'Example Domain', url: 'https://example.com/' }],
+            ...(wantsDeveloper
+              ? {
+                  developer: [
+                    {
+                      description: 'The matched passage.',
+                      title: 'Fix the retry loop',
+                      url: 'https://github.com/firecrawl/firecrawl/issues/1',
+                    },
+                  ],
+                }
+              : {}),
+          },
           id: '00000000-0000-4000-8000-000000000000',
           success: true,
         })
@@ -406,6 +426,46 @@ test('search firecrawl_search sends a clean body built from allowed fields only'
     sources: [{ type: 'web' }],
     origin: 'mcp-fastmcp',
   });
+});
+
+test('search firecrawl_search forwards the developer category and returns its group', async (t) => {
+  const backend = await startFakeBackend();
+  t.after(() => backend.close());
+  const { searchPort } = await startHostedServer(t, {
+    FIRECRAWL_API_URL: backend.url,
+  });
+
+  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 41,
+    method: 'tools/call',
+    params: {
+      arguments: {
+        query: 'retry loop backoff',
+        categories: ['developer'],
+        limit: 1,
+      },
+      name: 'firecrawl_search',
+    },
+    headers: { 'x-api-key': 'fc-search-key' },
+  });
+  assert.equal(res.status, 200);
+  const message = parseSseJson(await res.text());
+  assert.notEqual(message.result?.isError, true, JSON.stringify(message));
+
+  const searchCalls = backend.requests.filter((r) => r.url === '/v2/search');
+  assert.equal(searchCalls.length, 1);
+  assert.deepEqual(searchCalls[0].body.categories, ['developer']);
+
+  // The tool returns the API envelope unchanged, so the developer group must
+  // survive into the tool result.
+  const envelope = JSON.parse(message.result.content[0].text);
+  assert.deepEqual(envelope.data.developer, [
+    {
+      description: 'The matched passage.',
+      title: 'Fix the retry loop',
+      url: 'https://github.com/firecrawl/firecrawl/issues/1',
+    },
+  ]);
 });
 
 test('search surface requires authentication for tools/list', async (t) => {

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -10,6 +10,7 @@ import { assertAgentMetadataPolicy } from '../scripts/agent-metadata-policy.mjs'
 // appear on its tools/list or be callable through it.
 const SEARCH_TOOLS = [
   'firecrawl_search',
+  'firecrawl_developer_search',
   'firecrawl_research_search_papers',
   'firecrawl_research_inspect_paper',
   'firecrawl_research_related_papers',
@@ -181,6 +182,26 @@ async function startFakeBackend(options = {}) {
       return;
     }
 
+    if (req.method === 'GET' && req.url?.startsWith('/v2/developer/search')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          reranked: true,
+          results: [
+            {
+              id: 'issue:firecrawl/firecrawl#1',
+              passages: [{ text: 'The matched passage.' }],
+              title: 'Fix the retry loop',
+              type: 'issue',
+              url: 'https://github.com/firecrawl/firecrawl/issues/1',
+            },
+          ],
+          success: true,
+        })
+      );
+      return;
+    }
+
     res.writeHead(404, { 'content-type': 'application/json' });
     res.end(JSON.stringify({ error: `Unhandled ${req.method} ${req.url}` }));
   });
@@ -315,7 +336,7 @@ async function listTools(port, endpoint, headers) {
   return tools.map((tool) => tool.name);
 }
 
-test('search surface lists exactly the six read-only tools', async (t) => {
+test('search surface lists exactly the seven read-only tools', async (t) => {
   const { searchPort, getStderr } = await startHostedServer(t);
 
   const names = await listTools(searchPort, SEARCH_ENDPOINT, {
@@ -466,6 +487,46 @@ test('search firecrawl_search forwards the developer category and returns its gr
       url: 'https://github.com/firecrawl/firecrawl/issues/1',
     },
   ]);
+});
+
+test('search firecrawl_developer_search forwards query and k to the developer endpoint', async (t) => {
+  const backend = await startFakeBackend();
+  t.after(() => backend.close());
+  const { searchPort } = await startHostedServer(t, {
+    FIRECRAWL_API_URL: backend.url,
+  });
+
+  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 42,
+    method: 'tools/call',
+    params: {
+      arguments: { query: 'retry loop backoff', k: 5 },
+      name: 'firecrawl_developer_search',
+    },
+    headers: { 'x-api-key': 'fc-search-key' },
+  });
+  assert.equal(res.status, 200);
+  const message = parseSseJson(await res.text());
+  assert.notEqual(message.result?.isError, true, JSON.stringify(message));
+
+  const developerCalls = backend.requests.filter((r) =>
+    r.url.startsWith('/v2/developer/search')
+  );
+  assert.equal(developerCalls.length, 1);
+  assert.equal(developerCalls[0].method, 'GET');
+  assert.equal(
+    developerCalls[0].headers.authorization,
+    'Bearer fc-search-key'
+  );
+  const params = new URLSearchParams(developerCalls[0].url.split('?')[1]);
+  assert.equal(params.get('query'), 'retry loop backoff');
+  assert.equal(params.get('k'), '5');
+  assert.deepEqual([...params.keys()].sort(), ['k', 'query']);
+
+  const text = message.result.content[0].text;
+  assert.match(text, /\[issue:firecrawl\/firecrawl#1\] \(issue\) Fix the retry loop/);
+  assert.match(text, /https:\/\/github\.com\/firecrawl\/firecrawl\/issues\/1/);
+  assert.match(text, /The matched passage\./);
 });
 
 test('search surface requires authentication for tools/list', async (t) => {


### PR DESCRIPTION
The API serves a developer index built for coding agents: GitHub issues, merged pull requests, repository READMEs, and curated documentation sites. Research search has two surfaces in this client — a category and dedicated tools — and developer search now matches.

Category: `developer` joins the categories enum on `firecrawl_search` (full and search-surface tools). The tool posts through the SDK HTTP layer and returns the envelope unchanged, so the extra `data.developer` group needs no result-handling change. The descriptions state the group and its `{ url, title, description }` shape.

Dedicated tool: `firecrawl_developer_search` mirrors the research tools. It calls GET /v2/developer/search through the SDK HTTP layer and renders the ranked hits as markdown blocks (id, type, url, title, matched passages). It takes `query` and `k` only; the endpoint accepts no filters, and that narrow surface is deliberate. The search-surface allowlist grows to seven tools.

Tests: 61 pass, 0 fail (was 59). Lint clean. Both surfaces smoke-tested against the live API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4vZ6XH65bUJDkLthyfmvC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788097431&installation_model_id=11126&pr_number=344&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F344&signature=d6aaa5c17e3a1f08ec31966f6b251d53ae5407beda75cee882ed7dc33d07e965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `developer` category to `firecrawl_search` and introduces a dedicated `firecrawl_developer_search` tool so clients can query the developer index for programming questions and get ranked results.

- **New Features**
  - Accepts `developer` in the `categories` enum across full and search-surface tools.
  - Adds `firecrawl_developer_search` (GET `/v2/developer/search`) with `query` and optional `k`; returns ranked markdown blocks with id, type, url, title, and passages.
  - Documents `data.developer` as `{ url, title, description }` and updates copy to suggest `categories: ["developer"]` for programming queries.
  - Updates the search profile allowlist to include the developer tool and adds tests to ensure category forwarding, `query`/`k` propagation, and result formatting.

<sup>Written for commit 419558c4fac141c5f537acc3f4a3f746fa506da2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


