### PR TITLE
feat(mcp): accept skills on firecrawl_developer_search

### DIFF
--- a/src/developer.ts
+++ b/src/developer.ts
@@ -87,7 +87,7 @@ export function registerDeveloperTools(
       destructiveHint: false, // Query-only; no writes to external sources or the developer index.
     },
     description: `
-For a developer question — code behaviour, a library or framework, an API contract, an error message, or a known bug — search an index built for coding agents. The index covers GitHub issues, merged pull requests, repository READMEs, and curated documentation sites.
+For a developer question — code behaviour, a library or framework, an API contract, an error message, or a known bug — search an index built for coding agents. The index covers GitHub issues, merged pull requests, repository READMEs, and curated documentation sites. Set skills to "only" to limit the search to agent-skill files.
 
 Returns ranked results with an ID, source type, URL, title, and the matched passages in markdown.
 `,
@@ -105,12 +105,21 @@ Returns ranked results with an ID, source type, URL, title, and the matched pass
         .max(100)
         .optional()
         .describe('Number of ranked results to return (default 20).'),
+      skills: z
+        .enum(['only'])
+        .optional()
+        .describe('Set to "only" to search only agent-skill files.'),
     }),
     execute: async (args: unknown, { session }): Promise<string> => {
-      const { query, k } = args as { query: string; k?: number };
+      const { query, k, skills } = args as {
+        query: string;
+        k?: number;
+        skills?: 'only';
+      };
       const params = new URLSearchParams();
       params.append('query', query);
       if (k != null) params.append('k', String(k));
+      if (skills != null) params.append('skills', skills);
       const client = getClient(session) as ClientLike;
       const res = await client.http.get<{ results?: DeveloperHit[] }>(
         `${BASE}?${params.toString()}`,

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -529,6 +529,36 @@ test('search firecrawl_developer_search forwards query and k to the developer en
   assert.match(text, /The matched passage\./);
 });
 
+test('search firecrawl_developer_search forwards skills=only when requested', async (t) => {
+  const backend = await startFakeBackend();
+  t.after(() => backend.close());
+  const { searchPort } = await startHostedServer(t, {
+    FIRECRAWL_API_URL: backend.url,
+  });
+
+  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 43,
+    method: 'tools/call',
+    params: {
+      arguments: { query: 'scrape a page', skills: 'only' },
+      name: 'firecrawl_developer_search',
+    },
+    headers: { 'x-api-key': 'fc-search-key' },
+  });
+  assert.equal(res.status, 200);
+  const message = parseSseJson(await res.text());
+  assert.notEqual(message.result?.isError, true, JSON.stringify(message));
+
+  const developerCalls = backend.requests.filter((r) =>
+    r.url.startsWith('/v2/developer/search')
+  );
+  assert.equal(developerCalls.length, 1);
+  const params = new URLSearchParams(developerCalls[0].url.split('?')[1]);
+  assert.equal(params.get('query'), 'scrape a page');
+  assert.equal(params.get('skills'), 'only');
+  assert.deepEqual([...params.keys()].sort(), ['query', 'skills']);
+});
+
 test('search surface requires authentication for tools/list', async (t) => {
   const { searchPort, issuerUrl } = await startHostedServer(t);
 


### PR DESCRIPTION
firecrawl/firecrawl#4194 (merged) exposes a `skills` query param on GET /v2/developer/search, validated as `z.enum(["only"]).optional()`. This forwards it: `firecrawl_developer_search` gains an optional `skills` parameter (enum, single value `only`) sent as `skills=only`, and one description sentence states that it limits the search to agent-skill files.

The param is absent from the request when the caller omits it — the existing test pins the exact outbound key set, and a new test proves `skills=only` reaches the endpoint. The gateway side is already merged, so the flag works on arrival; the prod deploy had not picked it up yet at the time of writing (the API still rejects the key), which only affects when the value starts filtering, not this client change.

Tests: 62 pass, 0 fail (was 61). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4vZ6XH65bUJDkLthyfmvC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788288960&installation_model_id=11126&pr_number=346&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F346&signature=b1fb15bd2ff73ae1ba7173a452a340fe7e1a65119a609b505a60bd11aa993e6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional `skills` parameter to `firecrawl_developer_search` to filter results to agent-skill files. When set to `only`, it forwards `skills=only` to `GET /v2/developer/search`; otherwise the param is omitted, with a test verifying the behavior.

<sup>Written for commit cccd07e0d9f8e61c9a041e8a8f510447cba1124e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

