### PR TITLE
fix(mcp): distinguish keyless recovery paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -956,7 +956,8 @@ function recoveryPayload(
   options: { retryAfterSeconds?: number } = {}
 ): Record<string, unknown> {
   const retryAfterSeconds = options.retryAfterSeconds;
-  const isQuotaExhausted = code === 'KEYLESS_QUOTA_EXHAUSTED';
+  const isQuotaExhausted =
+    code === 'KEYLESS_QUOTA_EXHAUSTED' || code === 'KEYLESS_LIMIT_REACHED';
   const isToolUnavailable =
     code === 'KEYLESS_TOOL_NOT_AVAILABLE' ||
     code === 'KEYLESS_ACCESS_NOT_AVAILABLE';
@@ -2041,11 +2042,18 @@ async function keylessPost(
   });
   const json: any = await response.json().catch(() => ({}));
   if (!response.ok) {
-    if (isKeylessMode(session) && response.status === 429 && keylessQuotaReason(json?.reason)) {
-      const payload = recoveryPayload('KEYLESS_QUOTA_EXHAUSTED', session?.requestId, {
-        retryAfterSeconds: Number.isFinite(json?.retry_after_seconds) && json.retry_after_seconds > 0
-          ? json.retry_after_seconds
-          : undefined,
+    if (isKeylessMode(session) && response.status === 429) {
+      // The API normally supplies requests|credits. Preserve a structured,
+      // non-specific recovery payload during a skewed or legacy deployment.
+      const code = keylessQuotaReason(json?.reason)
+        ? 'KEYLESS_QUOTA_EXHAUSTED'
+        : 'KEYLESS_LIMIT_REACHED';
+      const payload = recoveryPayload(code, session?.requestId, {
+        retryAfterSeconds:
+          Number.isFinite(json?.retry_after_seconds) &&
+          json.retry_after_seconds > 0
+            ? json.retry_after_seconds
+            : undefined,
       });
       throw new UserError(String(payload.message), payload);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -960,6 +960,8 @@ function recoveryPayload(
     code === 'KEYLESS_QUOTA_EXHAUSTED' || code === 'KEYLESS_LIMIT_REACHED';
   const isToolUnavailable = code === 'KEYLESS_TOOL_NOT_AVAILABLE';
   const isKeylessAccessUnavailable = code === 'KEYLESS_ACCESS_NOT_AVAILABLE';
+  const isKeylessEligibilityUnavailable =
+    code === 'KEYLESS_ELIGIBILITY_UNAVAILABLE';
   const oauthUrl = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
   return {
     code,
@@ -974,11 +976,17 @@ function recoveryPayload(
             ? 'The free tier includes Search, Scrape, and Parse. This tool needs a connected account; Search, Scrape, and Parse still work, so no action is required.'
             : isKeylessAccessUnavailable
               ? 'Anonymous keyless access is unavailable for this request. To continue, connect a Firecrawl account via OAuth or configure an API key.'
-            : 'This tool requires a Firecrawl account or API key. Connect an account or configure Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.',
-    ...(isToolUnavailable ? { available_tools: [...KEYLESS_TOOL_NAMES] } : {}),
+              : isKeylessEligibilityUnavailable
+                ? 'The anonymous keyless eligibility check is temporarily unavailable. Retry shortly.'
+              : 'This tool requires a Firecrawl account or API key. Connect an account or configure Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.',
+    ...(isKeylessAccessUnavailable
+      ? {}
+      : { available_tools: [...KEYLESS_TOOL_NAMES] }),
     docs_url: 'https://docs.firecrawl.dev/mcp-server',
     ...(retryAfterSeconds ? { retry_after_seconds: retryAfterSeconds } : {}),
-    next_actions: isQuotaExhausted || isKeylessAccessUnavailable
+    next_actions: isKeylessEligibilityUnavailable
+      ? [{ kind: 'retry_later', after_seconds: 30 }]
+      : isQuotaExhausted || isKeylessAccessUnavailable
       ? [
           { kind: 'connect_oauth', url: oauthUrl, client_commands: [{ client: 'claude-code', command: 'claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth' }] },
           { kind: 'configure_api_key', header: 'Authorization: Bearer <FIRECRAWL_API_KEY>' },
@@ -1965,7 +1973,12 @@ function extractClientIp(request?: {
  * Read-only keyless check. MCP tool failures are returned in-band, not as an
  * OAuth transport challenge, so preserve only the quota details needed for recovery.
  */
-type KeylessEligibility = { eligible: boolean; reason?: string; retryAfterSeconds?: number };
+type KeylessEligibility = {
+  eligible: boolean;
+  reason?: string;
+  retryAfterSeconds?: number;
+  unavailable?: boolean;
+};
 
 function keylessQuotaReason(reason: unknown): reason is 'requests' | 'credits' {
   return reason === 'requests' || reason === 'credits';
@@ -1973,7 +1986,7 @@ function keylessQuotaReason(reason: unknown): reason is 'requests' | 'credits' {
 
 async function keylessEligible(clientIp: string): Promise<KeylessEligibility> {
   const secret = process.env.KEYLESS_PROXY_SECRET;
-  if (!secret) return { eligible: false };
+  if (!secret) return { eligible: false, unavailable: true };
   try {
     const response = await fetch(
       `${resolveApiBaseUrl()}/v2/keyless/eligibility`,
@@ -1985,8 +1998,11 @@ async function keylessEligible(clientIp: string): Promise<KeylessEligibility> {
         },
       }
     );
-    if (!response.ok) return { eligible: false };
-    const json: any = await response.json().catch(() => ({}));
+    if (!response.ok) return { eligible: false, unavailable: true };
+    const json: any = await response.json().catch(() => null);
+    if (typeof json?.eligible !== 'boolean') {
+      return { eligible: false, unavailable: true };
+    }
     return {
       eligible: json?.eligible === true,
       ...(typeof json?.reason === 'string' ? { reason: json.reason } : {}),
@@ -1995,7 +2011,7 @@ async function keylessEligible(clientIp: string): Promise<KeylessEligibility> {
         : {}),
     };
   } catch {
-    return { eligible: false };
+    return { eligible: false, unavailable: true };
   }
 }
 function isKeylessMode(session?: SessionData): boolean {
@@ -2017,9 +2033,11 @@ async function keylessPost(
       ? await keylessEligible(session.keylessClientIp)
       : { eligible: false };
     if (!eligibility.eligible) {
-      const code = keylessQuotaReason(eligibility.reason)
-        ? 'KEYLESS_QUOTA_EXHAUSTED'
-        : 'KEYLESS_ACCESS_NOT_AVAILABLE';
+      const code = eligibility.unavailable
+        ? 'KEYLESS_ELIGIBILITY_UNAVAILABLE'
+        : keylessQuotaReason(eligibility.reason)
+          ? 'KEYLESS_QUOTA_EXHAUSTED'
+          : 'KEYLESS_ACCESS_NOT_AVAILABLE';
       const payload = recoveryPayload(code, session?.requestId, {
         retryAfterSeconds: eligibility.retryAfterSeconds,
       });
@@ -2989,6 +3007,16 @@ if (
 registerMonitorTools(server);
 registerResearchTools(server, getClient);
 registerDeveloperTools(server, getClient);
+
+if (
+  process.env.CLOUD_SERVICE === 'true' &&
+  primaryProfile.allowKeyless &&
+  !normalizeHeader(process.env.KEYLESS_PROXY_SECRET)
+) {
+  console.warn(
+    '[firecrawl-mcp] KEYLESS_PROXY_SECRET is missing; keyless requests will be unavailable and /ready will fail.'
+  );
+}
 
 if (primaryProfile.id === 'search') {
   // The strict marketplace search tool intentionally replaces the full

--- a/src/index.ts
+++ b/src/index.ts
@@ -958,9 +958,8 @@ function recoveryPayload(
   const retryAfterSeconds = options.retryAfterSeconds;
   const isQuotaExhausted =
     code === 'KEYLESS_QUOTA_EXHAUSTED' || code === 'KEYLESS_LIMIT_REACHED';
-  const isToolUnavailable =
-    code === 'KEYLESS_TOOL_NOT_AVAILABLE' ||
-    code === 'KEYLESS_ACCESS_NOT_AVAILABLE';
+  const isToolUnavailable = code === 'KEYLESS_TOOL_NOT_AVAILABLE';
+  const isKeylessAccessUnavailable = code === 'KEYLESS_ACCESS_NOT_AVAILABLE';
   const oauthUrl = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
   return {
     code,
@@ -973,11 +972,13 @@ function recoveryPayload(
           ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now, connect a Firecrawl account via OAuth or configure an API key.`
           : isToolUnavailable
             ? 'The free tier includes Search, Scrape, and Parse. This tool needs a connected account; Search, Scrape, and Parse still work, so no action is required.'
+            : isKeylessAccessUnavailable
+              ? 'Anonymous keyless access is unavailable for this request. To continue, connect a Firecrawl account via OAuth or configure an API key.'
             : 'This tool requires a Firecrawl account or API key. Connect an account or configure Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.',
-    available_tools: [...KEYLESS_TOOL_NAMES],
+    ...(isToolUnavailable ? { available_tools: [...KEYLESS_TOOL_NAMES] } : {}),
     docs_url: 'https://docs.firecrawl.dev/mcp-server',
     ...(retryAfterSeconds ? { retry_after_seconds: retryAfterSeconds } : {}),
-    next_actions: isQuotaExhausted
+    next_actions: isQuotaExhausted || isKeylessAccessUnavailable
       ? [
           { kind: 'connect_oauth', url: oauthUrl, client_commands: [{ client: 'claude-code', command: 'claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth' }] },
           { kind: 'configure_api_key', header: 'Authorization: Bearer <FIRECRAWL_API_KEY>' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -952,8 +952,15 @@ function isHostedKeylessSession(session?: SessionData): boolean {
 
 function recoveryPayload(
   code: string,
-  requestId: string = randomUUID()
+  requestId: string = randomUUID(),
+  options: { retryAfterSeconds?: number } = {}
 ): Record<string, unknown> {
+  const retryAfterSeconds = options.retryAfterSeconds;
+  const isQuotaExhausted = code === 'KEYLESS_QUOTA_EXHAUSTED';
+  const isToolUnavailable =
+    code === 'KEYLESS_TOOL_NOT_AVAILABLE' ||
+    code === 'KEYLESS_ACCESS_NOT_AVAILABLE';
+  const oauthUrl = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
   return {
     code,
     request_id: requestId,
@@ -961,19 +968,27 @@ function recoveryPayload(
     message:
       code === 'CREDENTIAL_INVALID'
         ? 'The supplied Firecrawl credential is invalid or revoked. Replace it or reconnect the account, then retry.'
-        : 'This tool requires a Firecrawl account or API key. Connect an account or configure Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.',
+        : isQuotaExhausted
+          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now, connect a Firecrawl account via OAuth or configure an API key.`
+          : isToolUnavailable
+            ? 'The free tier includes Search, Scrape, and Parse. This tool needs a connected account; Search, Scrape, and Parse still work, so no action is required.'
+            : 'This tool requires a Firecrawl account or API key. Connect an account or configure Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.',
     available_tools: [...KEYLESS_TOOL_NAMES],
     docs_url: 'https://docs.firecrawl.dev/mcp-server',
-    next_actions: [
-      { kind: 'connect_account', url: 'https://firecrawl.dev/connect/mcp' },
-      {
-        kind: 'configure_api_key',
-        header: 'Authorization: Bearer <FIRECRAWL_API_KEY>',
-      },
-    ],
+    ...(retryAfterSeconds ? { retry_after_seconds: retryAfterSeconds } : {}),
+    next_actions: isQuotaExhausted
+      ? [
+          { kind: 'connect_oauth', url: oauthUrl, client_commands: [{ client: 'claude-code', command: 'claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth' }] },
+          { kind: 'configure_api_key', header: 'Authorization: Bearer <FIRECRAWL_API_KEY>' },
+        ]
+      : isToolUnavailable
+        ? [{ kind: 'continue_keyless', tools: [...KEYLESS_TOOL_NAMES] }]
+        : [
+            { kind: 'connect_oauth', url: oauthUrl },
+            { kind: 'configure_api_key', header: 'Authorization: Bearer <FIRECRAWL_API_KEY>' },
+          ],
   };
 }
-
 type ActionStatus = 'started' | 'success' | 'error';
 
 function emitActionLog(
@@ -981,7 +996,8 @@ function emitActionLog(
   status: ActionStatus,
   session?: SessionData,
   error?: unknown,
-  requestId = randomUUID()
+  requestId = randomUUID(),
+  code?: string
 ): void {
   if (process.env.CLOUD_SERVICE !== 'true') return;
   const payload = {
@@ -997,6 +1013,7 @@ function emitActionLog(
     ...(error
       ? { error_class: error instanceof Error ? error.name : typeof error }
       : {}),
+    ...(code ? { code } : {}),
   };
   console.error('[MCP_ACTION]', JSON.stringify(payload));
 
@@ -1036,6 +1053,9 @@ function guardHostedTool(
           : undefined;
       if (!code) return undefined;
       const payload = recoveryPayload(code);
+      if (logActions) {
+        emitActionLog(tool.name, 'error', session, new UserError(String(payload.message), payload), undefined, code);
+      }
       return {
         content: [{ type: 'text' as const, text: String(payload.message) }],
         isError: true,
@@ -1055,11 +1075,15 @@ function guardHostedTool(
       };
 
       if (invocationSession.credentialError) {
-        const payload = recoveryPayload('CREDENTIAL_INVALID', requestId);
+        const code = 'CREDENTIAL_INVALID';
+        const payload = recoveryPayload(code, requestId);
+        if (logActions) emitActionLog(tool.name, 'error', invocationSession, new UserError(String(payload.message), payload), requestId, code);
         throw new UserError(String(payload.message), payload);
       }
       if (isHostedKeylessSession(invocationSession) && !keylessTool) {
-        const payload = recoveryPayload('KEYLESS_TOOL_NOT_AVAILABLE', requestId);
+        const code = 'KEYLESS_TOOL_NOT_AVAILABLE';
+        const payload = recoveryPayload(code, requestId);
+        if (logActions) emitActionLog(tool.name, 'error', invocationSession, new UserError(String(payload.message), payload), requestId, code);
         throw new UserError(String(payload.message), payload);
       }
       if (!logActions) return execute(args, invocationContext);
@@ -1931,14 +1955,18 @@ function extractClientIp(request?: {
 }
 
 /**
- * Read-only check (no quota consumed) of whether a client IP can still use the
- * keyless free tier, via the API's secret-gated eligibility endpoint. Fails
- * closed: anything other than a clear "eligible: true" means fall through to the
- * OAuth challenge rather than silently granting keyless.
+ * Read-only keyless check. MCP tool failures are returned in-band, not as an
+ * OAuth transport challenge, so preserve only the quota details needed for recovery.
  */
-async function keylessEligible(clientIp: string): Promise<boolean> {
+type KeylessEligibility = { eligible: boolean; reason?: string; retryAfterSeconds?: number };
+
+function keylessQuotaReason(reason: unknown): reason is 'requests' | 'credits' {
+  return reason === 'requests' || reason === 'credits';
+}
+
+async function keylessEligible(clientIp: string): Promise<KeylessEligibility> {
   const secret = process.env.KEYLESS_PROXY_SECRET;
-  if (!secret) return false;
+  if (!secret) return { eligible: false };
   try {
     const response = await fetch(
       `${resolveApiBaseUrl()}/v2/keyless/eligibility`,
@@ -1950,14 +1978,19 @@ async function keylessEligible(clientIp: string): Promise<boolean> {
         },
       }
     );
-    if (!response.ok) return false;
+    if (!response.ok) return { eligible: false };
     const json: any = await response.json().catch(() => ({}));
-    return json?.eligible === true;
+    return {
+      eligible: json?.eligible === true,
+      ...(typeof json?.reason === 'string' ? { reason: json.reason } : {}),
+      ...(Number.isFinite(json?.retryAfterSeconds) && json.retryAfterSeconds > 0
+        ? { retryAfterSeconds: json.retryAfterSeconds }
+        : {}),
+    };
   } catch {
-    return false;
+    return { eligible: false };
   }
 }
-
 function isKeylessMode(session?: SessionData): boolean {
   if (hasCredential(session) || session?.credentialError) return false;
   if (process.env.CLOUD_SERVICE === 'true') {
@@ -1972,15 +2005,19 @@ async function keylessPost(
   body: Record<string, unknown>,
   session?: SessionData
 ): Promise<any> {
-  if (
-    isHostedKeylessSession(session) &&
-    (!session?.keylessClientIp || !(await keylessEligible(session.keylessClientIp)))
-  ) {
-    const payload = recoveryPayload(
-      'KEYLESS_ACCESS_NOT_AVAILABLE',
-      session?.requestId
-    );
-    throw new UserError(String(payload.message), payload);
+  if (isHostedKeylessSession(session)) {
+    const eligibility = session?.keylessClientIp
+      ? await keylessEligible(session.keylessClientIp)
+      : { eligible: false };
+    if (!eligibility.eligible) {
+      const code = keylessQuotaReason(eligibility.reason)
+        ? 'KEYLESS_QUOTA_EXHAUSTED'
+        : 'KEYLESS_ACCESS_NOT_AVAILABLE';
+      const payload = recoveryPayload(code, session?.requestId, {
+        retryAfterSeconds: eligibility.retryAfterSeconds,
+      });
+      throw new UserError(String(payload.message), payload);
+    }
   }
   const headers: Record<string, string> = {
     ...ORIGIN_HEADERS,
@@ -1999,11 +2036,12 @@ async function keylessPost(
   });
   const json: any = await response.json().catch(() => ({}));
   if (!response.ok) {
-    if (isHostedKeylessSession(session) && [401, 402, 429].includes(response.status)) {
-      const payload = recoveryPayload(
-        'KEYLESS_QUOTA_EXHAUSTED',
-        session?.requestId
-      );
+    if (isKeylessMode(session) && response.status === 429 && keylessQuotaReason(json?.reason)) {
+      const payload = recoveryPayload('KEYLESS_QUOTA_EXHAUSTED', session?.requestId, {
+        retryAfterSeconds: Number.isFinite(json?.retry_after_seconds) && json.retry_after_seconds > 0
+          ? json.retry_after_seconds
+          : undefined,
+      });
       throw new UserError(String(payload.message), payload);
     }
     throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1023,13 +1023,16 @@ function emitActionLog(
     normalizeHeader(process.env.FIRECRAWL_MCP_ACTION_LOG_URL) ??
     (apiUrl ? `${withoutTrailingSlash(apiUrl)}/v2/mcp/action-logs` : undefined);
   if (!secret || !endpoint || !payload.team_id || status === 'started') return;
+  // `code` is an MCP console-log discriminator, not part of the account-scoped
+  // action-log API contract.
+  const { code: _code, ...actionLogPayload } = payload;
   void fetch(endpoint, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${secret}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(payload),
+    body: JSON.stringify(actionLogPayload),
     signal: AbortSignal.timeout(1500),
   }).catch(() => undefined);
 }
@@ -1052,9 +1055,10 @@ function guardHostedTool(
           ? 'KEYLESS_TOOL_NOT_AVAILABLE'
           : undefined;
       if (!code) return undefined;
-      const payload = recoveryPayload(code);
+      const requestId = randomUUID();
+      const payload = recoveryPayload(code, requestId);
       if (logActions) {
-        emitActionLog(tool.name, 'error', session, new UserError(String(payload.message), payload), undefined, code);
+        emitActionLog(tool.name, 'error', session, new UserError(String(payload.message), payload), requestId, code);
       }
       return {
         content: [{ type: 'text' as const, text: String(payload.message) }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1025,7 +1025,8 @@ function emitActionLog(
   if (!secret || !endpoint || !payload.team_id || status === 'started') return;
   // `code` is an MCP console-log discriminator, not part of the account-scoped
   // action-log API contract.
-  const { code: _code, ...actionLogPayload } = payload;
+  const actionLogPayload = { ...payload };
+  delete actionLogPayload.code;
   void fetch(endpoint, {
     method: 'POST',
     headers: {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1053,6 +1053,14 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
       KEYLESS_PROXY_SECRET: 'keyless-secret',
       PORT: String(port),
     });
+    let cleanedUp = false;
+    const cleanup = async () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      await stopChild(child);
+      await backend.close();
+    };
+    t.after(cleanup);
     await waitForHealth(port, child);
     const response = await httpToolCall(port, {
       id: `keyless-${label}`,
@@ -1064,8 +1072,7 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
     assert.equal(result.structuredContent.code, expectedCode, label);
     assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth', label);
     if (label === 'with-reason') assert.equal(result.structuredContent.retry_after_seconds, 42);
-    await stopChild(child);
-    await backend.close();
+    await cleanup();
   }
 });
 

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -180,6 +180,7 @@ async function startFakeFirecrawlBackend(options = {}) {
     introspectionHandler,
     introspectionMetadata = {},
     keylessEligible = false,
+    searchResponse,
   } = options;
   const requests = [];
   const server = createServer(async (req, res) => {
@@ -237,6 +238,11 @@ async function startFakeFirecrawlBackend(options = {}) {
     }
 
     if (req.method === 'POST' && req.url === '/v2/search') {
+      if (searchResponse) {
+        res.writeHead(searchResponse.status, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(searchResponse.body));
+        return;
+      }
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(
         JSON.stringify({
@@ -941,6 +947,40 @@ test('HTTP cloud transport serves an eligible keyless client and forwards its IP
     'keyless-secret'
   );
   assert.equal(stderr.includes('TypeError'), false, stderr);
+});
+
+test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', async (t) => {
+  for (const [label, body, expectedCode] of [
+    ['with-reason', { error: 'limit', reason: 'credits', retry_after_seconds: 42 }, 'KEYLESS_QUOTA_EXHAUSTED'],
+    ['without-reason', { error: 'limit' }, 'KEYLESS_LIMIT_REACHED'],
+  ]) {
+    const backend = await startFakeFirecrawlBackend({
+      keylessEligible: true,
+      searchResponse: { status: 429, body },
+    });
+    const port = await getFreePort();
+    const child = spawnServer({
+      CLOUD_SERVICE: 'true',
+      FASTMCP_ENDPOINT: '/v2/mcp',
+      FIRECRAWL_API_URL: backend.url,
+      HTTP_STREAMABLE_SERVER: 'true',
+      KEYLESS_PROXY_SECRET: 'keyless-secret',
+      PORT: String(port),
+    });
+    await waitForHealth(port, child);
+    const response = await httpToolCall(port, {
+      id: `keyless-${label}`,
+      headers: { 'x-forwarded-for': '8.8.8.7' },
+      params: { arguments: { limit: 1, query: 'example domain' }, name: 'firecrawl_search' },
+    });
+    const result = parseSseJson(await response.text()).result;
+    assert.equal(result.isError, true, label);
+    assert.equal(result.structuredContent.code, expectedCode, label);
+    assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth', label);
+    if (label === 'with-reason') assert.equal(result.structuredContent.retry_after_seconds, 42);
+    await stopChild(child);
+    await backend.close();
+  }
 });
 
 test('HTTP cloud keyless Parse completes both phases without credentials and forwards redactPII', async (t) => {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -180,6 +180,7 @@ async function startFakeFirecrawlBackend(options = {}) {
     introspectionHandler,
     introspectionMetadata = {},
     keylessEligible = false,
+    keylessEligibilityResponse,
     searchResponse,
   } = options;
   const requests = [];
@@ -232,8 +233,12 @@ async function startFakeFirecrawlBackend(options = {}) {
 
     // Keyless free-tier eligibility (secret-gated, read-only).
     if (req.method === 'GET' && req.url === '/v2/keyless/eligibility') {
-      res.writeHead(200, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ eligible: keylessEligible }));
+      const response = keylessEligibilityResponse ?? {
+        status: 200,
+        body: { eligible: keylessEligible },
+      };
+      res.writeHead(response.status, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(response.body));
       return;
     }
 
@@ -949,6 +954,87 @@ test('HTTP cloud transport serves an eligible keyless client and forwards its IP
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
 
+test('HTTP cloud keyless returns retry recovery when eligibility is unavailable', async (t) => {
+  const backend = await startFakeFirecrawlBackend({
+    keylessEligibilityResponse: { status: 503, body: { error: 'unavailable' } },
+  });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    HTTP_STREAMABLE_SERVER: 'true',
+    KEYLESS_PROXY_SECRET: 'keyless-secret',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const response = await httpToolCall(port, {
+    id: 'keyless-eligibility-unavailable',
+    headers: { 'x-forwarded-for': '8.8.8.7' },
+    params: {
+      arguments: { limit: 1, query: 'example domain' },
+      name: 'firecrawl_search',
+    },
+  });
+  const result = parseSseJson(await response.text()).result;
+  assert.equal(result.isError, true);
+  assert.equal(
+    result.structuredContent.code,
+    'KEYLESS_ELIGIBILITY_UNAVAILABLE'
+  );
+  assert.deepEqual(result.structuredContent.next_actions, [
+    { kind: 'retry_later', after_seconds: 30 },
+  ]);
+  assert.equal(
+    result.structuredContent.available_tools.includes('firecrawl_search'),
+    true
+  );
+  assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
+});
+
+test('HTTP cloud keyless continues with free-tier tools when an account-only tool is selected', async (t) => {
+  const backend = await startFakeFirecrawlBackend({ keylessEligible: true });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    HTTP_STREAMABLE_SERVER: 'true',
+    KEYLESS_PROXY_SECRET: 'keyless-secret',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const response = await httpToolCall(port, {
+    id: 'keyless-account-only-tool',
+    headers: { 'x-forwarded-for': '8.8.8.7' },
+    params: {
+      arguments: { url: 'https://example.com/' },
+      name: 'firecrawl_crawl',
+    },
+  });
+  const result = parseSseJson(await response.text()).result;
+  assert.equal(result.isError, true);
+  assert.equal(result.structuredContent.code, 'KEYLESS_TOOL_NOT_AVAILABLE');
+  assert.deepEqual(result.structuredContent.next_actions, [
+    {
+      kind: 'continue_keyless',
+      tools: ['firecrawl_scrape', 'firecrawl_search', 'firecrawl_parse'],
+    },
+  ]);
+  assert.deepEqual(result.structuredContent.available_tools, [
+    'firecrawl_scrape',
+    'firecrawl_search',
+    'firecrawl_parse',
+  ]);
+  assert.equal(backend.requests.some((r) => r.url === '/v2/crawl'), false);
+});
+
 test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', async (t) => {
   for (const [label, body, expectedCode] of [
     ['with-reason', { error: 'limit', reason: 'credits', retry_after_seconds: 42 }, 'KEYLESS_QUOTA_EXHAUSTED'],
@@ -1302,6 +1388,31 @@ test('HTTP cloud transport returns recovery when keyless identity has no client 
   ]);
   assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
   assert.equal(stderr.includes('TypeError'), false, stderr);
+});
+
+test('hosted keyless warns when KEYLESS_PROXY_SECRET is missing', async (t) => {
+  const backend = await startFakeFirecrawlBackend();
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    KEYLESS_PROXY_SECRET: '',
+    PORT: String(port),
+  });
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const ready = await fetch(`http://127.0.0.1:${port}/ready`);
+  assert.equal(ready.status, 503);
+  assert.match(stderr, /KEYLESS_PROXY_SECRET is missing/);
 });
 
 test('account endpoint challenges anonymous clients and accepts API keys', async (t) => {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1141,6 +1141,8 @@ test('HTTP cloud keyless rejects multi-hop or malformed forwarded IP identity', 
     const result = parseSseJson(await response.text()).result;
     assert.equal(result.isError, true, xff);
     assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE', xff);
+    assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth', xff);
+    assert.equal(result.structuredContent.available_tools, undefined, xff);
   }
   assert.equal(backend.requests.length, 0, JSON.stringify(backend.requests));
 });
@@ -1292,6 +1294,8 @@ test('HTTP cloud transport returns recovery when keyless identity has no client 
   const result = parseSseJson(await toolCall.text()).result;
   assert.equal(result.isError, true);
   assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE');
+  assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth');
+  assert.equal(result.structuredContent.available_tools, undefined);
   assertServerGeneratedRequestId(result.structuredContent, [
     'client-json-rpc-id',
     'client-request-header-id',


### PR DESCRIPTION
## Summary
- Split keyless tool-unavailable, quota-exhausted, access-unavailable, eligibility-outage, and invalid-credential recovery payloads.
- Provide OAuth/API-key next actions for quota and real access failures; provide `retry_later` for eligibility dependency outages.
- Preserve structured 429 recovery during API/MCP deployment skew, log guard short-circuits, and warn when `KEYLESS_PROXY_SECRET` is absent.

## Compatibility
`available_tools` remains on existing payloads and is omitted only for `KEYLESS_ACCESS_NOT_AVAILABLE`, where it would be misleading.

## Validation
- Rebased cleanly on latest `main`.
- `npm run lint`
- `npm test`

## Deployment
Deploy after the companion API PR has passed CI and production has verified the structured quota body. The skew fallback prevents a correctness outage if deployment order changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788331735&installation_model_id=11126&pr_number=347&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F347&signature=6f99da8acee2f242471b1794710bbb82bc4fdd009d0541f643597c14e173e4b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Distinguishes keyless recovery paths with clearer messages and tailored next actions. Keeps 429 limit errors structured across deploy skew, stabilizes action log payloads, and warns when the keyless secret is missing.

- **Bug Fixes**
  - Split recovery into specific codes: `KEYLESS_QUOTA_EXHAUSTED`/`KEYLESS_LIMIT_REACHED`, `KEYLESS_TOOL_NOT_AVAILABLE`, `KEYLESS_ACCESS_NOT_AVAILABLE`, `KEYLESS_ELIGIBILITY_UNAVAILABLE`, and `CREDENTIAL_INVALID`; include `retry_after_seconds` when available.
  - Map next actions: `connect_oauth`/`configure_api_key` for quota/access failures, `retry_later` for eligibility outages, and `continue_keyless` listing free tools when an account‑only tool is chosen; omit `available_tools` for `KEYLESS_ACCESS_NOT_AVAILABLE`.
  - Preserve structured 429 recovery during API/MCP deploy skew; fall back to a non‑specific code if `reason` is absent.
  - Action logs: include a `code` in console output but strip it from the action‑log API payload; emit logs for recovery cases and warn when `KEYLESS_PROXY_SECRET` is missing (causes `/ready` to fail).

<sup>Written for commit f4508be63787c72cf183f23aabfdaffcdeeb22c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

