### PR TITLE
fix(mcp): keep feedback authenticated and factual

### DIFF
--- a/scripts/agent-metadata-policy.mjs
+++ b/scripts/agent-metadata-policy.mjs
@@ -23,6 +23,8 @@ const FEEDBACK_EXPLICIT_EXCHANGE =
   '\\b(?:in\\s+exchange\\s+for|in\\s+return\\s+for)\\b';
 const FEEDBACK_URGENCY =
   '\\b(?:immediately|right\\s+away|now|as\\s+soon\\s+as|every\\s+search|each\\s+search)\\b';
+const CONDITIONAL_REWARD_PREFIX =
+  '\\b(?:can|may)(?:\\s+be)?(?:\\s*,?\\s*subject\\s+to\\s+(?:the\\s+)?(?:daily\\s+)?(?:team\\s+)?cap\\s*,?)?\\s*$';
 
 function descriptions(language) {
   return (Array.isArray(language) ? language : [language]).map((description) =>
@@ -155,7 +157,7 @@ function containsUnconditionalFeedbackReward(statement) {
     }
     if (
       (creditOrRefundPattern.test(before) || creditOrRefundPattern.test(after)) &&
-      !/\b(?:can|may)(?:\s+be)?\s*$/i.test(before)
+      !new RegExp(CONDITIONAL_REWARD_PREFIX, 'i').test(before)
     ) {
       return true;
     }

--- a/scripts/agent-metadata-policy.mjs
+++ b/scripts/agent-metadata-policy.mjs
@@ -134,8 +134,19 @@ function containsPredicativeMandatorySelection(statement) {
 }
 
 function containsFeedbackSubmissionDirective(statement) {
+  return appearsInEitherOrder(
+    statement,
+    FEEDBACK_DIRECTIVE_ACTION,
+    FEEDBACK
+  );
+}
+
+function hasConditionalFeedbackRewardDisclosure(statement) {
+  // A factual disclosure must tie a conditional modal ("can" or "may") to
+  // the reward itself. A hedge elsewhere in the sentence must not exempt an
+  // unconditional reward-for-feedback claim.
   return new RegExp(
-    `${FEEDBACK_DIRECTIVE_ACTION}${WINDOW}${FEEDBACK}`,
+    `\\b(?:can|may)\\b${WINDOW}${FEEDBACK_REWARD_ACTION}${WINDOW}${CREDIT_OR_REFUND}`,
     'i'
   ).test(statement);
 }
@@ -152,7 +163,7 @@ function containsFeedbackInducement(statement) {
     containsFeedbackSubmissionDirective(statement) ||
     new RegExp(FEEDBACK_EXPLICIT_EXCHANGE, 'i').test(statement) ||
     (new RegExp(FEEDBACK_REWARD_ACTION, 'i').test(statement) &&
-      !new RegExp(FEEDBACK_CONDITIONAL_HEDGE, 'i').test(statement)) ||
+      !hasConditionalFeedbackRewardDisclosure(statement)) ||
     (new RegExp(FEEDBACK_URGENCY, 'i').test(statement) &&
       appearsInEitherOrder(statement, FEEDBACK, FEEDBACK_ACTION))
   );

--- a/scripts/agent-metadata-policy.mjs
+++ b/scripts/agent-metadata-policy.mjs
@@ -23,6 +23,8 @@ const FEEDBACK_EXPLICIT_EXCHANGE =
   '\\b(?:in\\s+exchange\\s+for|in\\s+return\\s+for)\\b';
 const FEEDBACK_URGENCY =
   '\\b(?:immediately|right\\s+away|now|as\\s+soon\\s+as|every\\s+search|each\\s+search)\\b';
+const FEEDBACK_CONDITIONAL_HEDGE =
+  '\\b(?:eligible|can|may|subject\\s+to|if\\s+(?:eligible|applicable|available)|when\\s+eligible)\\b';
 
 function descriptions(language) {
   return (Array.isArray(language) ? language : [language]).map((description) =>
@@ -149,6 +151,8 @@ function containsFeedbackInducement(statement) {
   return (
     containsFeedbackSubmissionDirective(statement) ||
     new RegExp(FEEDBACK_EXPLICIT_EXCHANGE, 'i').test(statement) ||
+    (new RegExp(FEEDBACK_REWARD_ACTION, 'i').test(statement) &&
+      !new RegExp(FEEDBACK_CONDITIONAL_HEDGE, 'i').test(statement)) ||
     (new RegExp(FEEDBACK_URGENCY, 'i').test(statement) &&
       appearsInEitherOrder(statement, FEEDBACK, FEEDBACK_ACTION))
   );
@@ -227,8 +231,9 @@ function containsNearbyDefaultCoercion(statements) {
   return firstNearbyStatementPair(statements, containsAdjacentDefaultCoercion);
 }
 
-// Product decision (2026-08-01): factual, conditional refund disclosures are
-// permitted. Imperative, urgent, or quid-pro-quo refund language is not.
+// Product decision — Himadri (2026-08-01): factual, conditional refund
+// disclosures are permitted. Imperative, urgent, quid-pro-quo, and
+// unconditional reward language is not.
 const FEEDBACK_INDUCEMENT_RULE = {
   id: 'feedback-credit-refund-inducement',
   label: 'feedback credit/refund inducement (not factual disclosure)',

--- a/scripts/agent-metadata-policy.mjs
+++ b/scripts/agent-metadata-policy.mjs
@@ -18,13 +18,11 @@ const FEEDBACK_ACTION =
 const FEEDBACK_DIRECTIVE_ACTION =
   '\\b(?:submit(?:s|ted|ting)?|send(?:s|ing)?|provide(?:s|d|ing)?|leave(?:s|ing)?|share(?:s|d|ing)?|give(?:s|n|ing)?|rate(?:s|d|ing)?|complete(?:s|d|ing)?)\\b';
 const FEEDBACK_REWARD_ACTION =
-  '\\b(?:earn(?:s|ed|ing)?|receiv(?:e|es|ed|ing)|get|issu(?:e|es|ed|ing)|qualif(?:y|ies)|reward(?:s|ed|ing)?|grant(?:s|ed|ing)?)\\b';
+  '\\b(?:earn(?:s|ed|ing)?|receiv(?:e|es|ed|ing)|get|issu(?:e|es|ed|ing)|qualif(?:y|ies)|reward(?:s|ed|ing)?|refund(?:s|ed|ing)?|grant(?:s|ed|ing)?)\\b';
 const FEEDBACK_EXPLICIT_EXCHANGE =
   '\\b(?:in\\s+exchange\\s+for|in\\s+return\\s+for)\\b';
 const FEEDBACK_URGENCY =
   '\\b(?:immediately|right\\s+away|now|as\\s+soon\\s+as|every\\s+search|each\\s+search)\\b';
-const FEEDBACK_CONDITIONAL_HEDGE =
-  '\\b(?:eligible|can|may|subject\\s+to|if\\s+(?:eligible|applicable|available)|when\\s+eligible)\\b';
 
 function descriptions(language) {
   return (Array.isArray(language) ? language : [language]).map((description) =>
@@ -141,14 +139,29 @@ function containsFeedbackSubmissionDirective(statement) {
   );
 }
 
-function hasConditionalFeedbackRewardDisclosure(statement) {
-  // A factual disclosure must tie a conditional modal ("can" or "may") to
-  // the reward itself. A hedge elsewhere in the sentence must not exempt an
-  // unconditional reward-for-feedback claim.
-  return new RegExp(
-    `\\b(?:can|may)\\b${WINDOW}${FEEDBACK_REWARD_ACTION}${WINDOW}${CREDIT_OR_REFUND}`,
-    'i'
-  ).test(statement);
+function containsUnconditionalFeedbackReward(statement) {
+  const rewardActionPattern = new RegExp(FEEDBACK_REWARD_ACTION, 'gi');
+  const creditOrRefundPattern = new RegExp(CREDIT_OR_REFUND, 'i');
+
+  for (const match of statement.matchAll(rewardActionPattern)) {
+    const start = match.index ?? 0;
+    const before = statement.slice(Math.max(0, start - 80), start);
+    const after = statement.slice(start + match[0].length, start + match[0].length + 80);
+    if (
+      /^refund/i.test(match[0]) &&
+      !/^\s+(?:(?:a|an|one|\d+)\s+)?credits?\b/i.test(after)
+    ) {
+      continue;
+    }
+    if (
+      (creditOrRefundPattern.test(before) || creditOrRefundPattern.test(after)) &&
+      !/\b(?:can|may)\b\s*$/i.test(before)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function containsFeedbackInducement(statement) {
@@ -162,8 +175,7 @@ function containsFeedbackInducement(statement) {
   return (
     containsFeedbackSubmissionDirective(statement) ||
     new RegExp(FEEDBACK_EXPLICIT_EXCHANGE, 'i').test(statement) ||
-    (new RegExp(FEEDBACK_REWARD_ACTION, 'i').test(statement) &&
-      !hasConditionalFeedbackRewardDisclosure(statement)) ||
+    containsUnconditionalFeedbackReward(statement) ||
     (new RegExp(FEEDBACK_URGENCY, 'i').test(statement) &&
       appearsInEitherOrder(statement, FEEDBACK, FEEDBACK_ACTION))
   );
@@ -174,10 +186,7 @@ function containsFeedbackSubmission(statement) {
 }
 
 function containsCreditOrRefundReward(statement) {
-  return (
-    new RegExp(CREDIT_OR_REFUND, 'i').test(statement) &&
-    new RegExp(FEEDBACK_REWARD_ACTION, 'i').test(statement)
-  );
+  return containsUnconditionalFeedbackReward(statement);
 }
 
 function containsAdjacentFeedbackInducement(first, second) {

--- a/scripts/agent-metadata-policy.mjs
+++ b/scripts/agent-metadata-policy.mjs
@@ -155,7 +155,7 @@ function containsUnconditionalFeedbackReward(statement) {
     }
     if (
       (creditOrRefundPattern.test(before) || creditOrRefundPattern.test(after)) &&
-      !/\b(?:can|may)\b\s*$/i.test(before)
+      !/\b(?:can|may)(?:\s+be)?\s*$/i.test(before)
     ) {
       return true;
     }

--- a/scripts/agent-metadata-policy.mjs
+++ b/scripts/agent-metadata-policy.mjs
@@ -15,12 +15,14 @@ const FEEDBACK = '\\bfeedback\\b';
 const CREDIT_OR_REFUND = '\\b(?:credit|credits|refund|refunds)\\b';
 const FEEDBACK_ACTION =
   '\\b(?:submit|send|provide|leave|share|give|rate|report|offer|complete|earn(?:s|ed|ing)?|receiv(?:e|es|ed|ing)|get|issu(?:e|es|ed|ing)|qualif(?:y|ies)|reward(?:s|ed)?)\\b';
-const FEEDBACK_SUBMISSION_ACTION =
-  '\\b(?:submit(?:s|ted|ting)?|send(?:s|ing)?|provide(?:s|d|ing)?|leave(?:s|ing)?|share(?:s|d|ing)?|give(?:s|n|ing)?|rate(?:s|d|ing)?|report(?:s|ed|ing)?|offer(?:s|ed|ing)?|complete(?:s|d|ing)?)\\b';
+const FEEDBACK_DIRECTIVE_ACTION =
+  '\\b(?:submit(?:s|ted|ting)?|send(?:s|ing)?|provide(?:s|d|ing)?|leave(?:s|ing)?|share(?:s|d|ing)?|give(?:s|n|ing)?|rate(?:s|d|ing)?|complete(?:s|d|ing)?)\\b';
 const FEEDBACK_REWARD_ACTION =
   '\\b(?:earn(?:s|ed|ing)?|receiv(?:e|es|ed|ing)|get|issu(?:e|es|ed|ing)|qualif(?:y|ies)|reward(?:s|ed|ing)?|grant(?:s|ed|ing)?)\\b';
-const FEEDBACK_EXCHANGE =
-  '\\b(?:for|after|upon|when|in\\s+exchange\\s+for|in\\s+return\\s+for)\\b';
+const FEEDBACK_EXPLICIT_EXCHANGE =
+  '\\b(?:in\\s+exchange\\s+for|in\\s+return\\s+for)\\b';
+const FEEDBACK_URGENCY =
+  '\\b(?:immediately|right\\s+away|now|as\\s+soon\\s+as|every\\s+search|each\\s+search)\\b';
 
 function descriptions(language) {
   return (Array.isArray(language) ? language : [language]).map((description) =>
@@ -129,6 +131,13 @@ function containsPredicativeMandatorySelection(statement) {
   ).test(statement);
 }
 
+function containsFeedbackSubmissionDirective(statement) {
+  return new RegExp(
+    `${FEEDBACK_DIRECTIVE_ACTION}${WINDOW}${FEEDBACK}`,
+    'i'
+  ).test(statement);
+}
+
 function containsFeedbackInducement(statement) {
   if (
     !new RegExp(FEEDBACK, 'i').test(statement) ||
@@ -138,15 +147,15 @@ function containsFeedbackInducement(statement) {
   }
 
   return (
-    appearsInEitherOrder(statement, FEEDBACK, FEEDBACK_ACTION) ||
-    appearsInEitherOrder(statement, CREDIT_OR_REFUND, FEEDBACK_ACTION) ||
-    appearsInEitherOrder(statement, FEEDBACK, FEEDBACK_EXCHANGE) ||
-    appearsInEitherOrder(statement, CREDIT_OR_REFUND, FEEDBACK_EXCHANGE)
+    containsFeedbackSubmissionDirective(statement) ||
+    new RegExp(FEEDBACK_EXPLICIT_EXCHANGE, 'i').test(statement) ||
+    (new RegExp(FEEDBACK_URGENCY, 'i').test(statement) &&
+      appearsInEitherOrder(statement, FEEDBACK, FEEDBACK_ACTION))
   );
 }
 
 function containsFeedbackSubmission(statement) {
-  return appearsInEitherOrder(statement, FEEDBACK, FEEDBACK_SUBMISSION_ACTION);
+  return containsFeedbackSubmissionDirective(statement);
 }
 
 function containsCreditOrRefundReward(statement) {
@@ -218,9 +227,11 @@ function containsNearbyDefaultCoercion(statements) {
   return firstNearbyStatementPair(statements, containsAdjacentDefaultCoercion);
 }
 
+// Product decision (2026-08-01): factual, conditional refund disclosures are
+// permitted. Imperative, urgent, or quid-pro-quo refund language is not.
 const FEEDBACK_INDUCEMENT_RULE = {
   id: 'feedback-credit-refund-inducement',
-  label: 'feedback credit/refund inducement',
+  label: 'feedback credit/refund inducement (not factual disclosure)',
   violates: containsFeedbackInducement,
 };
 

--- a/scripts/agent-metadata-policy.mjs
+++ b/scripts/agent-metadata-policy.mjs
@@ -23,8 +23,10 @@ const FEEDBACK_EXPLICIT_EXCHANGE =
   '\\b(?:in\\s+exchange\\s+for|in\\s+return\\s+for)\\b';
 const FEEDBACK_URGENCY =
   '\\b(?:immediately|right\\s+away|now|as\\s+soon\\s+as|every\\s+search|each\\s+search)\\b';
-const CONDITIONAL_REWARD_PREFIX =
-  '\\b(?:can|may)(?:\\s+be)?(?:\\s*,?\\s*subject\\s+to\\s+(?:the\\s+)?(?:daily\\s+)?(?:team\\s+)?cap\\s*,?)?\\s*$';
+const CONDITIONAL_REWARD_CAP =
+  '\\bsubject\\s+to\\s+(?:the\\s+)?(?:daily\\s+)?(?:team\\s+)?cap\\b';
+const PERSONAL_REWARD_PROMISE =
+  '\\byou\\s+(?:can|may|will)\\s+(?:earn(?:s|ed|ing)?|receiv(?:e|es|ed|ing)|get|qualif(?:y|ies)|be\\s+(?:issued|rewarded|granted))\\b';
 
 function descriptions(language) {
   return (Array.isArray(language) ? language : [language]).map((description) =>
@@ -141,9 +143,22 @@ function containsFeedbackSubmissionDirective(statement) {
   );
 }
 
+function isFactualConditionalReward(statement) {
+  if (new RegExp(PERSONAL_REWARD_PROMISE, 'i').test(statement)) {
+    return false;
+  }
+
+  const hasEligibility = /\beligible\b/i.test(statement);
+  const hasCap = new RegExp(CONDITIONAL_REWARD_CAP, 'i').test(statement);
+  const hasConditionalModal = /\b(?:can|may)\b/i.test(statement);
+
+  return (hasConditionalModal && (hasEligibility || hasCap)) || (hasEligibility && hasCap);
+}
+
 function containsUnconditionalFeedbackReward(statement) {
   const rewardActionPattern = new RegExp(FEEDBACK_REWARD_ACTION, 'gi');
   const creditOrRefundPattern = new RegExp(CREDIT_OR_REFUND, 'i');
+  const factualConditionalReward = isFactualConditionalReward(statement);
 
   for (const match of statement.matchAll(rewardActionPattern)) {
     const start = match.index ?? 0;
@@ -157,7 +172,7 @@ function containsUnconditionalFeedbackReward(statement) {
     }
     if (
       (creditOrRefundPattern.test(before) || creditOrRefundPattern.test(after)) &&
-      !new RegExp(CONDITIONAL_REWARD_PREFIX, 'i').test(before)
+      !factualConditionalReward
     ) {
       return true;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2160,7 +2160,7 @@ if (!SEARCH_FEEDBACK_DISABLED && !isLocalKeylessStartup()) {
       destructiveHint: false, // Additive only; records feedback and may refund credits, does not delete data.
     },
     description: `
-Records schema-validated quality feedback for a prior \`firecrawl_search\` UUID \`searchId\`. A \`good\` rating requires a valuable source, \`partial\` a valuable source or missing topic, and \`bad\` a missing topic or query suggestion; caps are 50 \`valuableSources\` and 20 \`missingContent\` entries.
+Records schema-validated quality feedback for a prior \`firecrawl_search\` UUID \`searchId\`. A \`good\` rating requires a valuable source, \`partial\` a valuable source or at least one \`missingContent\` entry, and \`bad\` at least one \`missingContent\` entry or a query suggestion; caps are 50 \`valuableSources\` and 20 \`missingContent\` entries.
 
 Eligibility is limited to successful searches within the feedback age window. The record is idempotent per search ID. Eligible first feedback for a search can refund 1 credit; refunds are subject to the team's daily cap. The response reports whether a refund was applied, along with submission and daily-cap status.
 `,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1867,7 +1867,7 @@ Search web, news, or image sources and return ranked results. Operators include 
 
 For a programming question, add \`categories: ["developer"]\`. It searches an index of GitHub issues, merged pull requests, repository READMEs, and curated documentation sites, and returns the hits in \`data.developer\` beside the web results.
 
-\`scrapeOptions\` can attach extracted page content. Returns source-type result groups and usage metadata.
+\`scrapeOptions\` can attach extracted page content. Returns source-type result groups and usage metadata. Authenticated responses can include an \`id\` for optional search feedback.
 `,
   parameters: z
     .object({
@@ -1916,8 +1916,7 @@ For a programming question, add \`categories: ["developer"]\`. It searches an in
     // Call /v2/search through the SDK's HTTP layer (auth + retries) instead
     // of `client.search()` so we preserve the full response envelope. The
     // high-level `search()` helper strips `id` and `creditsUsed`, which
-    // breaks the `firecrawl_search_feedback` workflow that this server
-    // explicitly tells the LLM to use after every search.
+    // supports the optional authenticated `firecrawl_search_feedback` workflow.
     const client = getClient(session);
     const httpRes = await (client as any).http.post('/v2/search', searchBody);
     return asText(httpRes?.data ?? {});
@@ -2163,7 +2162,7 @@ if (!SEARCH_FEEDBACK_DISABLED && !isLocalKeylessStartup()) {
     description: `
 Records schema-validated quality feedback for a prior \`firecrawl_search\` UUID \`searchId\`. A \`good\` rating requires a valuable source, \`partial\` a valuable source or missing topic, and \`bad\` a missing topic or query suggestion; caps are 50 \`valuableSources\` and 20 \`missingContent\` entries.
 
-Eligibility is limited to successful searches within the feedback age window. The record is idempotent per search ID. Returns submission and daily-cap status with accounting fields.
+Eligibility is limited to successful searches within the feedback age window. The record is idempotent per search ID. Eligible first feedback for a search can refund 1 credit (a search costs 2); refunds are subject to the team's daily cap. The response reports whether a refund was applied, along with submission and daily-cap status.
 `,
     parameters: z.object({
       searchId: z

--- a/src/index.ts
+++ b/src/index.ts
@@ -2162,7 +2162,7 @@ if (!SEARCH_FEEDBACK_DISABLED && !isLocalKeylessStartup()) {
     description: `
 Records schema-validated quality feedback for a prior \`firecrawl_search\` UUID \`searchId\`. A \`good\` rating requires a valuable source, \`partial\` a valuable source or missing topic, and \`bad\` a missing topic or query suggestion; caps are 50 \`valuableSources\` and 20 \`missingContent\` entries.
 
-Eligibility is limited to successful searches within the feedback age window. The record is idempotent per search ID. Eligible first feedback for a search can refund 1 credit (a search costs 2); refunds are subject to the team's daily cap. The response reports whether a refund was applied, along with submission and daily-cap status.
+Eligibility is limited to successful searches within the feedback age window. The record is idempotent per search ID. Eligible first feedback for a search can refund 1 credit; refunds are subject to the team's daily cap. The response reports whether a refund was applied, along with submission and daily-cap status.
 `,
     parameters: z.object({
       searchId: z

--- a/src/index.ts
+++ b/src/index.ts
@@ -1909,7 +1909,8 @@ For a programming question, add \`categories: ["developer"]\`. It searches an in
       const json = await keylessPost('/v2/search', searchBody, session);
       // Search feedback requires an authenticated account. Do not expose its
       // identifier to keyless clients, where it would invite an unusable call.
-      const { id: _feedbackId, ...keylessResponse } = json ?? {};
+      const keylessResponse = { ...(json ?? {}) };
+      delete keylessResponse.id;
       return asText(keylessResponse);
     }
     // Call /v2/search through the SDK's HTTP layer (auth + retries) instead

--- a/src/index.ts
+++ b/src/index.ts
@@ -950,6 +950,17 @@ function isHostedKeylessSession(session?: SessionData): boolean {
   );
 }
 
+// A stdio client without a cloud credential can use only the keyless tools.
+// Do this at registration time so unsupported feedback tools are not advertised.
+function isLocalKeylessStartup(): boolean {
+  return (
+    process.env.CLOUD_SERVICE !== 'true' &&
+    !isHttpStreamingTransport() &&
+    !resolveCredentialFromEnv() &&
+    !normalizeHeader(process.env.FIRECRAWL_API_URL)
+  );
+}
+
 function recoveryPayload(
   code: string,
   requestId: string = randomUUID()
@@ -1856,7 +1867,7 @@ Search web, news, or image sources and return ranked results. Operators include 
 
 For a programming question, add \`categories: ["developer"]\`. It searches an index of GitHub issues, merged pull requests, repository READMEs, and curated documentation sites, and returns the hits in \`data.developer\` beside the web results.
 
-\`scrapeOptions\` can attach extracted page content. Returns source-type result groups, an \`id\` for optional search feedback, and usage metadata.
+\`scrapeOptions\` can attach extracted page content. Returns source-type result groups and usage metadata.
 `,
   parameters: z
     .object({
@@ -1896,7 +1907,10 @@ For a programming question, add \`categories: ["developer"]\`. It searches an in
     };
     if (isKeylessMode(session)) {
       const json = await keylessPost('/v2/search', searchBody, session);
-      return asText(json ?? {});
+      // Search feedback requires an authenticated account. Do not expose its
+      // identifier to keyless clients, where it would invite an unusable call.
+      const { id: _feedbackId, ...keylessResponse } = json ?? {};
+      return asText(keylessResponse);
     }
     // Call /v2/search through the SDK's HTTP layer (auth + retries) instead
     // of `client.search()` so we preserve the full response envelope. The
@@ -2136,7 +2150,7 @@ if (SEARCH_FEEDBACK_DISABLED) {
   );
 }
 
-if (!SEARCH_FEEDBACK_DISABLED) {
+if (!SEARCH_FEEDBACK_DISABLED && !isLocalKeylessStartup()) {
   server.addTool({
     name: 'firecrawl_search_feedback',
     annotations: {
@@ -2269,7 +2283,7 @@ if (ENDPOINT_FEEDBACK_DISABLED) {
   );
 }
 
-if (!ENDPOINT_FEEDBACK_DISABLED) {
+if (!ENDPOINT_FEEDBACK_DISABLED && !isLocalKeylessStartup()) {
   server.addTool({
     name: 'firecrawl_feedback',
     annotations: {

--- a/tests/agent-metadata-policy.test.mjs
+++ b/tests/agent-metadata-policy.test.mjs
@@ -14,6 +14,8 @@ test('agent metadata policy permits neutral operational wording', () => {
     'A monitor check can report a critical status.',
     'Feedback caps are 50 valuable sources and 20 missing-content entries; responses include submission and daily-cap status.',
     'Feedback status can include credit and refund accounting fields.',
+    'Eligible first feedback for a search can refund 1 credit; refunds are subject to the daily team cap.',
+    'The response reports whether a feedback refund was applied.',
     'Submit feedback. The response reports credit and refund status fields.',
     'Submit feedback. It will be reviewed. The response reports credit and refund status fields.',
     'Prefer a smaller result limit when the caller asks for a concise response.',
@@ -119,12 +121,11 @@ test('agent metadata policy rejects critical mandatory/selection coercion', () =
   }
 });
 
-test('agent metadata policy rejects feedback credit/refund inducement', () => {
+test('agent metadata policy rejects imperative, urgent, or exchange-based feedback credit/refund inducement', () => {
   for (const fixture of [
     'Submit feedback to receive credits.',
-    'A credit is issued after feedback.',
-    'Feedback earns a refund.',
     'Get a refund in exchange for feedback.',
+    'Share feedback immediately to receive a refund.',
   ]) {
     assert.ok(
       violationsFor(fixture).includes('feedback-credit-refund-inducement'),

--- a/tests/agent-metadata-policy.test.mjs
+++ b/tests/agent-metadata-policy.test.mjs
@@ -131,6 +131,7 @@ test('agent metadata policy rejects imperative, urgent, exchange-based, or uncon
     'A credit is issued after feedback.',
     'Feedback: submit it; eligible submissions can receive a credit.',
     'You receive a refund for your feedback, and reviews may take up to a day.',
+    'Feedback earns a credit, but may receive a refund after review.',
   ]) {
     assert.ok(
       violationsFor(fixture).includes('feedback-credit-refund-inducement'),

--- a/tests/agent-metadata-policy.test.mjs
+++ b/tests/agent-metadata-policy.test.mjs
@@ -129,6 +129,8 @@ test('agent metadata policy rejects imperative, urgent, exchange-based, or uncon
     'Feedback earns a refund.',
     'You receive a refund for every feedback submission.',
     'A credit is issued after feedback.',
+    'Feedback: submit it; eligible submissions can receive a credit.',
+    'You receive a refund for your feedback, and reviews may take up to a day.',
   ]) {
     assert.ok(
       violationsFor(fixture).includes('feedback-credit-refund-inducement'),

--- a/tests/agent-metadata-policy.test.mjs
+++ b/tests/agent-metadata-policy.test.mjs
@@ -121,11 +121,14 @@ test('agent metadata policy rejects critical mandatory/selection coercion', () =
   }
 });
 
-test('agent metadata policy rejects imperative, urgent, or exchange-based feedback credit/refund inducement', () => {
+test('agent metadata policy rejects imperative, urgent, exchange-based, or unconditional feedback credit/refund inducement', () => {
   for (const fixture of [
     'Submit feedback to receive credits.',
     'Get a refund in exchange for feedback.',
     'Share feedback immediately to receive a refund.',
+    'Feedback earns a refund.',
+    'You receive a refund for every feedback submission.',
+    'A credit is issued after feedback.',
   ]) {
     assert.ok(
       violationsFor(fixture).includes('feedback-credit-refund-inducement'),

--- a/tests/agent-metadata-policy.test.mjs
+++ b/tests/agent-metadata-policy.test.mjs
@@ -17,6 +17,7 @@ test('agent metadata policy permits neutral operational wording', () => {
     'Eligible first feedback for a search can refund 1 credit; refunds are subject to the daily team cap.',
     'A one-credit refund may be issued for eligible search feedback.',
     'Eligible search feedback may, subject to the daily team cap, receive a credit.',
+    'A credit is issued for eligible search feedback, subject to the daily team cap.',
     'The response reports whether a feedback refund was applied.',
     'Submit feedback. The response reports credit and refund status fields.',
     'Submit feedback. It will be reviewed. The response reports credit and refund status fields.',
@@ -134,6 +135,8 @@ test('agent metadata policy rejects imperative, urgent, exchange-based, or uncon
     'Feedback: submit it; eligible submissions can receive a credit.',
     'You receive a refund for your feedback, and reviews may take up to a day.',
     'Feedback earns a credit, but may receive a refund after review.',
+    'You can earn a credit by providing feedback.',
+    'You may earn a credit for feedback, subject to the daily team cap.',
   ]) {
     assert.ok(
       violationsFor(fixture).includes('feedback-credit-refund-inducement'),

--- a/tests/agent-metadata-policy.test.mjs
+++ b/tests/agent-metadata-policy.test.mjs
@@ -15,6 +15,7 @@ test('agent metadata policy permits neutral operational wording', () => {
     'Feedback caps are 50 valuable sources and 20 missing-content entries; responses include submission and daily-cap status.',
     'Feedback status can include credit and refund accounting fields.',
     'Eligible first feedback for a search can refund 1 credit; refunds are subject to the daily team cap.',
+    'A one-credit refund may be issued for eligible search feedback.',
     'The response reports whether a feedback refund was applied.',
     'Submit feedback. The response reports credit and refund status fields.',
     'Submit feedback. It will be reviewed. The response reports credit and refund status fields.',

--- a/tests/agent-metadata-policy.test.mjs
+++ b/tests/agent-metadata-policy.test.mjs
@@ -16,6 +16,7 @@ test('agent metadata policy permits neutral operational wording', () => {
     'Feedback status can include credit and refund accounting fields.',
     'Eligible first feedback for a search can refund 1 credit; refunds are subject to the daily team cap.',
     'A one-credit refund may be issued for eligible search feedback.',
+    'Eligible search feedback may, subject to the daily team cap, receive a credit.',
     'The response reports whether a feedback refund was applied.',
     'Submit feedback. The response reports credit and refund status fields.',
     'Submit feedback. It will be reviewed. The response reports credit and refund status fields.',

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -628,7 +628,7 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   );
   assert.match(
     byName.get('firecrawl_search_feedback').description,
-    /good.*valuable source.*partial.*missing topic.*bad.*query suggestion/is
+    /good.*valuable source.*partial.*missingContent.*bad.*missingContent.*query suggestion/is
   );
   assert.match(
     byName.get('firecrawl_search_feedback').description,
@@ -637,6 +637,10 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   assert.match(
     byName.get('firecrawl_search_feedback').description,
     /eligible first feedback.*can refund 1 credit.*daily cap.*response reports whether a refund was applied/is
+  );
+  assert.doesNotMatch(
+    byName.get('firecrawl_search_feedback').description,
+    /costs?\s+2\s+credits?/i
   );
   assert.match(
     byName.get('firecrawl_research_search_papers').description,

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -659,7 +659,7 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
 
-test('local keyless stdio omits feedback tools and search-feedback framing', async (t) => {
+test('local keyless stdio omits feedback tools and qualifies search-feedback IDs as authenticated-only', async (t) => {
   const child = spawnServer({
     FIRECRAWL_API_KEY: '',
     FIRECRAWL_API_URL: '',
@@ -680,7 +680,10 @@ test('local keyless stdio omits feedback tools and search-feedback framing', asy
   assert.equal(toolNames.includes('firecrawl_feedback'), false);
   const search = tools.tools.find((tool) => tool.name === 'firecrawl_search');
   assert.ok(search);
-  assert.doesNotMatch(search.description, /id.*feedback/i);
+  assert.match(
+    search.description,
+    /authenticated responses can include an `id` for optional search feedback/i
+  );
 });
 
 test('monitor create gives queries precedence over page targets', async (t) => {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -635,6 +635,10 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
     /50.*valuableSources.*20.*missingContent.*feedback age window.*idempotent.*daily-cap/is
   );
   assert.match(
+    byName.get('firecrawl_search_feedback').description,
+    /eligible first feedback.*can refund 1 credit.*daily cap.*response reports whether a refund was applied/is
+  );
+  assert.match(
     byName.get('firecrawl_research_search_papers').description,
     /topics represented in the indexed corpus/i
   );

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -659,6 +659,30 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
 
+test('local keyless stdio omits feedback tools and search-feedback framing', async (t) => {
+  const child = spawnServer({
+    FIRECRAWL_API_KEY: '',
+    FIRECRAWL_API_URL: '',
+    FIRECRAWL_OAUTH_TOKEN: '',
+  });
+  t.after(() => stopChild(child));
+
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'firecrawl-local-keyless', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+  const tools = await client.request('tools/list');
+  const toolNames = tools.tools.map((tool) => tool.name);
+  assert.equal(toolNames.includes('firecrawl_search_feedback'), false);
+  assert.equal(toolNames.includes('firecrawl_feedback'), false);
+  const search = tools.tools.find((tool) => tool.name === 'firecrawl_search');
+  assert.ok(search);
+  assert.doesNotMatch(search.description, /id.*feedback/i);
+});
+
 test('monitor create gives queries precedence over page targets', async (t) => {
   const fakeApi = await startFakeFirecrawlApi();
   t.after(() => fakeApi.close());
@@ -929,6 +953,8 @@ test('HTTP cloud transport serves an eligible keyless client and forwards its IP
   assert.equal(toolCall.status, 200);
   const message = parseSseJson(await toolCall.text());
   assert.notEqual(message.result.isError, true);
+  const keylessSearchPayload = JSON.parse(message.result.content[0].text);
+  assert.equal('id' in keylessSearchPayload, false);
 
   const eligibilityCalls = backend.requests.filter(
     (r) => r.url === '/v2/keyless/eligibility'


### PR DESCRIPTION
## Summary
- Remove feedback tools from credential-less local stdio and strip feedback IDs from keyless Search results.
- Keep authenticated feedback discoverable through an explicitly auth-qualified Search ID description.
- Disclose the eligible, conditional one-credit Search-feedback refund without imperative or reward-inducement language.
- Enforce that distinction in metadata-policy tests.

## Why
Keyless Search previously invited a follow-up feedback call that keyless could never authenticate, producing guard errors or raw 401s. Authenticated feedback remains available and its actual refund behavior is now described factually.

## Validation
- Rebased cleanly on latest `main`.
- `npm run lint`
- `npm test`

## Release gate
Confirm OpenAI resubmission/review timing before deploying the changed agent-visible wording. This PR intentionally does not restore an immediate-feedback CTA or enable keyless feedback.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788331737&installation_model_id=11126&pr_number=348&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F348&signature=a46ebe8e065795796fe2e0e072db48594a1bd6f9229fc12d546477fd1bc418f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide feedback tools for keyless clients and keep refund language factual, conditional, and capped. Prevents unauthenticated feedback calls and aligns tool text with the updated metadata policy.

- **Bug Fixes**
  - Do not register `firecrawl_search_feedback` or `firecrawl_feedback` on local keyless stdio; strip `id` from keyless `firecrawl_search` responses and state that feedback IDs appear only on authenticated responses.
  - Update `firecrawl_search_feedback` description: rating rules (e.g., `partial` needs a valuable source or at least one `missingContent`; `bad` needs `missingContent` or a query suggestion). Report whether an eligible first‑feedback 1‑credit refund was applied, subject to the team’s daily cap; remove any “costs 2 credits” wording.

- **Refactors**
  - Tighten the metadata‑policy guard: require eligibility and/or daily‑cap conditions for any refund mention; allow passive “can/may” disclosures when properly scoped; block imperative, urgent, quid‑pro‑quo, unconditional reward language, and personal reward promises (e.g., “you can earn a credit”). Update tests for these cases, keyless startup behavior, and keyless search responses without `id`.

<sup>Written for commit 3a9968cf0f4108082edd14855ebd4100b7faa98d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

