### PR TITLE
chore: bump MCP package to 3.23.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.firecrawl/firecrawl-mcp-server",
   "title": "Firecrawl MCP Server",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web.",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "repository": {
     "url": "https://github.com/firecrawl/firecrawl-mcp-server.git",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "firecrawl-mcp",
-      "version": "3.23.0",
+      "version": "3.23.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- bumps the npm package and MCP registry metadata to `3.23.1` after the keyless recovery and feedback releases

## Validation
- parsed both JSON manifests
- `git diff --check`

No runtime behavior changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788378925&installation_model_id=11126&pr_number=350&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F350&signature=4e470fe5dd2960ae4e7a13f2946279b34acd9cfe0fb39256dc846c6087094f85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `firecrawl-mcp` and MCP registry metadata to 3.23.1. No runtime behavior changes.

<sup>Written for commit 8049f684254dd7086f844f09a9fe94eaf45d5be7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

