### PR TITLE
fix: restore the six-tool marketplace search contract

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -832,14 +832,13 @@ const KEYLESS_PROFILE_INSTRUCTIONS = `Without authentication, this endpoint expo
 
 // The search surface exposes web/research search only. Its instructions and tool
 // copy describe just those tools and stay neutral about how a client uses them.
-const SEARCH_PROFILE_INSTRUCTIONS = `Firecrawl provides web, developer, and research search. Use firecrawl_search to find relevant results across the web and specialized indexes. For a programming question, call firecrawl_developer_search — or firecrawl_search with categories: ["developer"] — to search indexed GitHub issues, merged pull requests, READMEs, and documentation. Use the firecrawl_research_* tools to search academic and research literature, expand from anchor papers via the citation graph, read full-text passages from a specific paper, and search public code repositories. All tools are read-only and return ranked results.`;
+const SEARCH_PROFILE_INSTRUCTIONS = `Firecrawl provides web, developer, and research search. Use firecrawl_search to find relevant results across the web and specialized indexes. For a programming question, use firecrawl_search with categories: ["developer"] to search indexed GitHub issues, merged pull requests, READMEs, and documentation. Use the firecrawl_research_* tools to search academic and research literature, expand from anchor papers via the citation graph, read full-text passages from a specific paper, and search public code repositories. All tools are read-only and return ranked results.`;
 
 // The exact set of tools the search surface exposes. Registration is filtered
 // against this set, so anything not listed here can never appear on that
 // instance's tools/list or be called through it.
 const SEARCH_PROFILE_TOOLS = new Set<string>([
   'firecrawl_search',
-  'firecrawl_developer_search',
   'firecrawl_research_search_papers',
   'firecrawl_research_inspect_paper',
   'firecrawl_research_related_papers',
@@ -3072,7 +3071,6 @@ if (searchProfileEnabled) {
   };
 
   registerResearchTools(searchRegistrar, getClient);
-  registerDeveloperTools(searchRegistrar, getClient);
   registerMarketplaceSearchTool(searchRegistrar, getClient);
 
   // Isolate the search instance from the already-serving full instance: if it

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -10,7 +10,6 @@ import { assertAgentMetadataPolicy } from '../scripts/agent-metadata-policy.mjs'
 // appear on its tools/list or be callable through it.
 const SEARCH_TOOLS = [
   'firecrawl_search',
-  'firecrawl_developer_search',
   'firecrawl_research_search_papers',
   'firecrawl_research_inspect_paper',
   'firecrawl_research_related_papers',
@@ -29,6 +28,7 @@ const EXCLUDED_TOOLS = [
   'firecrawl_interact',
   'firecrawl_parse',
   'firecrawl_monitor_create',
+  'firecrawl_developer_search',
   'firecrawl_search_feedback',
   'firecrawl_feedback',
 ];
@@ -182,26 +182,6 @@ async function startFakeBackend(options = {}) {
       return;
     }
 
-    if (req.method === 'GET' && req.url?.startsWith('/v2/developer/search')) {
-      res.writeHead(200, { 'content-type': 'application/json' });
-      res.end(
-        JSON.stringify({
-          reranked: true,
-          results: [
-            {
-              id: 'issue:firecrawl/firecrawl#1',
-              passages: [{ text: 'The matched passage.' }],
-              title: 'Fix the retry loop',
-              type: 'issue',
-              url: 'https://github.com/firecrawl/firecrawl/issues/1',
-            },
-          ],
-          success: true,
-        })
-      );
-      return;
-    }
-
     res.writeHead(404, { 'content-type': 'application/json' });
     res.end(JSON.stringify({ error: `Unhandled ${req.method} ${req.url}` }));
   });
@@ -336,7 +316,7 @@ async function listTools(port, endpoint, headers) {
   return tools.map((tool) => tool.name);
 }
 
-test('search surface lists exactly the seven read-only tools', async (t) => {
+test('search surface lists exactly the six read-only tools', async (t) => {
   const { searchPort, getStderr } = await startHostedServer(t);
 
   const names = await listTools(searchPort, SEARCH_ENDPOINT, {
@@ -489,76 +469,6 @@ test('search firecrawl_search forwards the developer category and returns its gr
   ]);
 });
 
-test('search firecrawl_developer_search forwards query and k to the developer endpoint', async (t) => {
-  const backend = await startFakeBackend();
-  t.after(() => backend.close());
-  const { searchPort } = await startHostedServer(t, {
-    FIRECRAWL_API_URL: backend.url,
-  });
-
-  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
-    id: 42,
-    method: 'tools/call',
-    params: {
-      arguments: { query: 'retry loop backoff', k: 5 },
-      name: 'firecrawl_developer_search',
-    },
-    headers: { 'x-api-key': 'fc-search-key' },
-  });
-  assert.equal(res.status, 200);
-  const message = parseSseJson(await res.text());
-  assert.notEqual(message.result?.isError, true, JSON.stringify(message));
-
-  const developerCalls = backend.requests.filter((r) =>
-    r.url.startsWith('/v2/developer/search')
-  );
-  assert.equal(developerCalls.length, 1);
-  assert.equal(developerCalls[0].method, 'GET');
-  assert.equal(
-    developerCalls[0].headers.authorization,
-    'Bearer fc-search-key'
-  );
-  const params = new URLSearchParams(developerCalls[0].url.split('?')[1]);
-  assert.equal(params.get('query'), 'retry loop backoff');
-  assert.equal(params.get('k'), '5');
-  assert.deepEqual([...params.keys()].sort(), ['k', 'query']);
-
-  const text = message.result.content[0].text;
-  assert.match(text, /\[issue:firecrawl\/firecrawl#1\] \(issue\) Fix the retry loop/);
-  assert.match(text, /https:\/\/github\.com\/firecrawl\/firecrawl\/issues\/1/);
-  assert.match(text, /The matched passage\./);
-});
-
-test('search firecrawl_developer_search forwards skills=only when requested', async (t) => {
-  const backend = await startFakeBackend();
-  t.after(() => backend.close());
-  const { searchPort } = await startHostedServer(t, {
-    FIRECRAWL_API_URL: backend.url,
-  });
-
-  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
-    id: 43,
-    method: 'tools/call',
-    params: {
-      arguments: { query: 'scrape a page', skills: 'only' },
-      name: 'firecrawl_developer_search',
-    },
-    headers: { 'x-api-key': 'fc-search-key' },
-  });
-  assert.equal(res.status, 200);
-  const message = parseSseJson(await res.text());
-  assert.notEqual(message.result?.isError, true, JSON.stringify(message));
-
-  const developerCalls = backend.requests.filter((r) =>
-    r.url.startsWith('/v2/developer/search')
-  );
-  assert.equal(developerCalls.length, 1);
-  const params = new URLSearchParams(developerCalls[0].url.split('?')[1]);
-  assert.equal(params.get('query'), 'scrape a page');
-  assert.equal(params.get('skills'), 'only');
-  assert.deepEqual([...params.keys()].sort(), ['query', 'skills']);
-});
-
 test('search surface requires authentication for tools/list', async (t) => {
   const { searchPort, issuerUrl } = await startHostedServer(t);
 
@@ -707,6 +617,7 @@ test('full surface still exposes its complete tool set alongside the search surf
   const names = await listTools(fullPort, '/v2/mcp', { 'x-api-key': 'fc-test' });
   assert.ok(names.includes('firecrawl_scrape'));
   assert.ok(names.includes('firecrawl_search'));
+  assert.ok(names.includes('firecrawl_developer_search'));
   assert.ok(names.includes('firecrawl_parse'));
   assert.ok(names.length > SEARCH_TOOLS.length);
 


### PR DESCRIPTION
## Summary

- Remove `firecrawl_developer_search` from `/v2/mcp-search`
- Restore the exact six-tool surface agreed with Anthropic
- Keep `firecrawl_developer_search` available on the full MCP endpoint
- Update instructions and contract tests to prevent future drift

## Why

Anthropic approved and reviewed `/v2/mcp-search` against an explicit six-tool contract. Adding another tool caused the deployed surface to differ from the submission and exposed a beta-gated tool that returned 403 during review.

The marketplace search endpoint is a reviewed external contract, not a general-purpose search profile. Tool additions require coordinated updates to the partner agreement, submission metadata, documentation, tests, and reviewer access before deployment.

## Test plan

- `npm test`
- 65 tests passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788432099&installation_model_id=11126&pr_number=352&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F352&signature=87cbcb4c3aa66dfbe9a69ca776a539af9148e837d78c68f3fbea2cfad9880d4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the exact six-tool contract for `/v2/mcp-search` by removing `firecrawl_developer_search` from the marketplace search surface. Keeps the developer search on the full `/v2/mcp` endpoint and updates instructions/tests to prevent drift.

- **Bug Fixes**
  - Removed `firecrawl_developer_search` from the search profile tools and registration.
  - Updated search instructions to use `firecrawl_search` with `categories: ["developer"]`.
  - Adjusted contract tests to expect six read-only tools; removed developer search tests; verified the full surface still exposes `firecrawl_developer_search`.
  - Cleaned up unused fake backend handling for developer search.

<sup>Written for commit ededfd88ee064a535508e9ee96526f104d580eba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

