### PR TITLE
chore(mcp): point developer search at /v2/search/developer and document it for GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Model Context Protocol (MCP) server that brings [Firecrawl](https://github.com
 ## Features
 
 - Search the web and get full page content
+- Search an index built for coding agents: GitHub issues, merged pull requests, READMEs, and docs
 - Scrape any URL into clean, structured data
 - Interact with pages — click, navigate, and operate
 - Deep research with autonomous agent
@@ -275,6 +276,7 @@ Use this guide to select the right tool for your task:
 - **If you have multiple known URLs:** call **scrape** for each URL. If you specifically need one bulk API operation, use the Firecrawl API batch endpoint outside MCP.
 - **If you need to discover URLs on a site:** use **map**
 - **If you want to search the web for info:** use **search**
+- **If you have a programming question** (a library, an API contract, an error message, a known bug): use **developer search**
 - **If you need complex research across multiple unknown sources:** use **agent**
 - **If you want to analyze a whole site or section:** use **crawl** (with limits!)
 - **If you need interactive browser automation** (click, type, navigate): use **interact** with a URL for a fresh page, or **scrape** + **interact** when you already scraped the page or need tighter scrape control
@@ -290,6 +292,7 @@ Use this guide to select the right tool for your task:
 | parse        | Files and hosted upload refs                   | markdown, JSON, or document output |
 | extract      | Structured extraction from URLs                | JSON structured data           |
 | search       | Web search for info                            | results[]                      |
+| developer    | Programming questions over developer sources   | results[] with passages        |
 | agent        | Complex multi-source research                  | JSON (structured data)         |
 | monitor      | Recurring page checks                          | monitor/check metadata and diffs |
 | research     | Paper and GitHub repository research           | research results and repo matches |
@@ -936,6 +939,33 @@ Pass `body` when you need crawl targets, JSON change tracking, custom retention,
 - `firecrawl_monitor_delete`: delete a monitor (destructive; only call when the user intends to remove it).
 - `firecrawl_monitor_checks`: list checks, optionally filtered by status.
 - `firecrawl_monitor_check`: get page-level results, including `diff`, `snapshot`, `judgment.meaningful`, and `judgment.meaningfulChanges`.
+
+### 14. Developer Search Tool (`firecrawl_developer_search`)
+
+Search an index built for coding agents. The index covers GitHub issues, merged pull requests, repository READMEs, and curated documentation sites.
+
+**Best for:** A programming question — code behaviour, a library or framework, an API contract, an error message, or a known bug.
+
+**Arguments:**
+
+```json
+{
+  "name": "firecrawl_developer_search",
+  "arguments": {
+    "query": "how do I configure retries",
+    "k": 10,
+    "skills": "only"
+  }
+}
+```
+
+- `query` (required): the developer question or search phrase.
+- `k`: number of ranked results. The default is 10 and the maximum is 100.
+- `skills`: set to `"only"` to search agent-skill files alone.
+
+**Returns:** Ranked results. Each result carries an ID, a source type (`issue`, `pull_request`, `readme`, or `doc`), a URL, a title, and the matched passages in markdown.
+
+`firecrawl_search` with `categories: ["developer"]` searches the same index beside the web results. Use this tool instead when you want the passages and no web results. The search-only endpoint does not expose this tool; it keeps its fixed set of six tools, and `firecrawl_search` reaches the developer index there.
 
 ## Logging System
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.23.2",
+  "version": "3.23.3",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.firecrawl/firecrawl-mcp-server",
   "title": "Firecrawl MCP Server",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web.",
-  "version": "3.23.2",
+  "version": "3.23.3",
   "repository": {
     "url": "https://github.com/firecrawl/firecrawl-mcp-server.git",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "firecrawl-mcp",
-      "version": "3.23.2",
+      "version": "3.23.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/developer.ts
+++ b/src/developer.ts
@@ -1,7 +1,7 @@
 /**
- * Firecrawl Developer search tool (experimental).
+ * Firecrawl Developer search tool.
  *
- * Thin MCP wrapper over the `/v2/developer/search` endpoint (GitHub issues,
+ * Thin MCP wrapper over the `/v2/search/developer` endpoint (GitHub issues,
  * merged pull requests, repository READMEs, and curated documentation sites).
  *
  * The installed `@mendable/firecrawl-js` predates a `developer` client, so we
@@ -32,7 +32,8 @@ type ClientLike = {
 // the callback loosely and narrow to `ClientLike` at each call site.
 type GetClient = (session?: SessionData) => unknown;
 
-const BASE = '/v2/developer/search';
+// The other mount, /v2/developer/search, may be withdrawn.
+const BASE = '/v2/search/developer';
 const ORIGIN_HEADERS = { 'X-Origin': 'mcp-fastmcp' };
 
 // Cap the matched passages per result so a page of hits stays within the MCP
@@ -104,7 +105,7 @@ Returns ranked results with an ID, source type, URL, title, and the matched pass
         .min(1)
         .max(100)
         .optional()
-        .describe('Number of ranked results to return (default 20).'),
+        .describe('Number of ranked results to return (default 10).'),
       skills: z
         .enum(['only'])
         .optional()


### PR DESCRIPTION
`firecrawl_developer_search` calls `/v2/developer/search`. That is the path that may be withdrawn; `/v2/search/developer` is the public one. A published MCP package cannot be re-pointed after the fact.

Also corrects a stale fact in agent-visible text: the API returns 10 results by default, not 20. The tool sends no `k` of its own, so the server default is what the agent gets.

Developer search leaves beta, so the tool now appears in the README beside the other tools — the Features list, the tool-choice guide, the quick-reference table, and a section of its own. The section states that the search-only endpoint does not expose the tool and that `firecrawl_search` reaches the same index there, so the six-tool contract of #352 is not contradicted.

3.23.2 is on npm, so this bumps to 3.23.3 in `package.json` and both `server.json` fields. Merging pushes `package.json` to main, which triggers the publish workflow on its own.

## No beta gate here

There is no client-side beta gate to remove. `registerDeveloperTools` runs unconditionally and the tool carries no beta labelling. The only entitlement gate is server-side, on `developerBeta` in the API controller, so this PR is independent of that flag removal and can merge in either order.

Two exclusions stay as they are, because neither is a beta gate:

- The search profile allowlist omits the tool, which #352 set deliberately.
- Hosted keyless sessions cannot list or call it, because it is not in `KEYLESS_TOOL_NAMES`. Adding it is a billing decision, not a launch fix.

## Testing

`pnpm run build`, `pnpm test` (65 tests), and `pnpm run lint` all pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788461464&installation_model_id=11126&pr_number=353&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F353&signature=989e7b72b709c7034d92f0e752d2653fe454802b810212a495359e462c389787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the developer search tool to the public `/v2/search/developer` endpoint and documents the tool for GA. Also corrects the default result count and bumps the package to 3.23.3.

- **Bug Fixes**
  - Point `firecrawl_developer_search` to `/v2/search/developer` (was `/v2/developer/search`).
  - Correct `k` description: default is 10 results.

- **New Features**
  - Add developer search to the README (features list, tool-choice guide, quick-reference table, and a new section).
  - Clarify that the search-only endpoint doesn’t expose this tool; use `firecrawl_search` with `categories: ["developer"]` there.

<sup>Written for commit 93a018060bcd43a35a9681cac558674bae91f620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

