### PR TITLE
fix(mcp): put keyless recovery behind a human decision

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -960,6 +960,17 @@ function isLocalKeylessStartup(): boolean {
   );
 }
 
+// Conversion is the user's decision, not the agent's: the payload asks the model
+// to put the choice to a human rather than to start an account flow itself.
+const CONNECT_ACCOUNT_GUIDANCE =
+  'ask the user to connect a Firecrawl account via OAuth or configure an API key.';
+
+// Interactive OAuth belongs to the dedicated account resource. `/v2/mcp` accepts
+// API keys and OAuth tokens already bound to it, but never initiates sign-in,
+// and it does not accept new tokens minted for the account resource. The
+// same-URL upgrade from keyless is the API key; OAuth is a move to `/v2/mcp-oauth`.
+const MCP_OAUTH_CONNECT_URL = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
+
 function recoveryPayload(
   code: string,
   requestId: string = randomUUID(),
@@ -972,7 +983,13 @@ function recoveryPayload(
   const isKeylessAccessUnavailable = code === 'KEYLESS_ACCESS_NOT_AVAILABLE';
   const isKeylessEligibilityUnavailable =
     code === 'KEYLESS_ELIGIBILITY_UNAVAILABLE';
-  const oauthUrl = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
+  // Advisory to the model, not a protocol signal a client acts on: nothing here
+  // opens a browser. The harness starts its own auth flow once a human agrees,
+  // so name the account resource and stay client-agnostic about how to reach it.
+  const connectOauthAction = {
+    kind: 'connect_via_oauth',
+    url: MCP_OAUTH_CONNECT_URL,
+  };
   return {
     code,
     request_id: requestId,
@@ -981,30 +998,25 @@ function recoveryPayload(
       code === 'CREDENTIAL_INVALID'
         ? 'The supplied Firecrawl credential is invalid or revoked. Replace it or reconnect the account, then retry.'
         : isQuotaExhausted
-          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now, connect a Firecrawl account via OAuth or configure an API key.`
+          ? `The free daily limit has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue with higher limits now, ${CONNECT_ACCOUNT_GUIDANCE}`
           : isToolUnavailable
             ? 'The free tier includes Search, Scrape, and Parse. This tool needs a connected account; Search, Scrape, and Parse still work, so no action is required.'
             : isKeylessAccessUnavailable
-              ? 'Anonymous keyless access is unavailable for this request. To continue, connect a Firecrawl account via OAuth or configure an API key.'
+              ? `Anonymous keyless access is unavailable for this request. To continue, ${CONNECT_ACCOUNT_GUIDANCE}`
               : isKeylessEligibilityUnavailable
                 ? 'The anonymous keyless eligibility check is temporarily unavailable. Retry shortly.'
               : 'This tool requires a Firecrawl account or API key. Connect an account or configure Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.',
     ...(isKeylessAccessUnavailable
       ? {}
-      : { available_tools: [...KEYLESS_TOOL_NAMES] }),
+      : { keyless_tools: [...KEYLESS_TOOL_NAMES] }),
     docs_url: 'https://docs.firecrawl.dev/mcp-server',
     ...(retryAfterSeconds ? { retry_after_seconds: retryAfterSeconds } : {}),
     next_actions: isKeylessEligibilityUnavailable
       ? [{ kind: 'retry_later', after_seconds: 30 }]
-      : isQuotaExhausted || isKeylessAccessUnavailable
-      ? [
-          { kind: 'connect_oauth', url: oauthUrl, client_commands: [{ client: 'claude-code', command: 'claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth' }] },
-          { kind: 'configure_api_key', header: 'Authorization: Bearer <FIRECRAWL_API_KEY>' },
-        ]
       : isToolUnavailable
         ? [{ kind: 'continue_keyless', tools: [...KEYLESS_TOOL_NAMES] }]
         : [
-            { kind: 'connect_oauth', url: oauthUrl },
+            connectOauthAction,
             { kind: 'configure_api_key', header: 'Authorization: Bearer <FIRECRAWL_API_KEY>' },
           ],
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -960,16 +960,19 @@ function isLocalKeylessStartup(): boolean {
   );
 }
 
-// Conversion is the user's decision, not the agent's: the payload asks the model
-// to put the choice to a human rather than to start an account flow itself.
-const CONNECT_ACCOUNT_GUIDANCE =
-  'ask the user to connect a Firecrawl account via OAuth or configure an API key.';
-
 // Interactive OAuth belongs to the dedicated account resource. `/v2/mcp` accepts
 // API keys and OAuth tokens already bound to it, but never initiates sign-in,
 // and it does not accept new tokens minted for the account resource. The
 // same-URL upgrade from keyless is the API key; OAuth is a move to `/v2/mcp-oauth`.
 const MCP_OAUTH_CONNECT_URL = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
+
+// Conversion is the user's decision, not the agent's, so the copy sends the
+// choice to a human first. After a yes, the move is to retarget the server entry
+// the client already has: the account resource challenges anonymous connects, so
+// repointing it is what makes the client open its own browser flow. Registering
+// a second entry instead leaves the in-use one keyless and duplicates the tools.
+const CONNECT_ACCOUNT_GUIDANCE =
+  "Ask the user first. If they agree, replace this Firecrawl server's URL while preserving its name and scope, initiate the client's OAuth flow, then retry. If interactive OAuth is unavailable, offer an API key. Do not modify MCP configuration before consent.";
 
 function recoveryPayload(
   code: string,
@@ -984,11 +987,19 @@ function recoveryPayload(
   const isKeylessEligibilityUnavailable =
     code === 'KEYLESS_ELIGIBILITY_UNAVAILABLE';
   // Advisory to the model, not a protocol signal a client acts on: nothing here
-  // opens a browser. The harness starts its own auth flow once a human agrees,
-  // so name the account resource and stay client-agnostic about how to reach it.
+  // opens a browser. Name the target, mark that it replaces the current entry
+  // rather than adding one, and leave the mechanics to the harness. Retargeting
+  // edits the user's client config, so the consent gate is data and not only
+  // prose: an agent reading next_actions alone must still see it.
   const connectOauthAction = {
     kind: 'connect_via_oauth',
     url: MCP_OAUTH_CONNECT_URL,
+    requires_user_consent: true,
+    // Nothing to replace when this deployment already is the account resource,
+    // which is reachable here through CREDENTIAL_INVALID.
+    ...(withoutTrailingSlash(primaryProfile.resourceUrl) === MCP_OAUTH_CONNECT_URL
+      ? {}
+      : { replace_current_server: true }),
   };
   return {
     code,
@@ -998,11 +1009,11 @@ function recoveryPayload(
       code === 'CREDENTIAL_INVALID'
         ? 'The supplied Firecrawl credential is invalid or revoked. Replace it or reconnect the account, then retry.'
         : isQuotaExhausted
-          ? `The free daily limit has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue with higher limits now, ${CONNECT_ACCOUNT_GUIDANCE}`
+          ? `The free daily limit has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue with higher limits now: ${CONNECT_ACCOUNT_GUIDANCE}`
           : isToolUnavailable
             ? 'The free tier includes Search, Scrape, and Parse. This tool needs a connected account; Search, Scrape, and Parse still work, so no action is required.'
             : isKeylessAccessUnavailable
-              ? `Anonymous keyless access is unavailable for this request. To continue, ${CONNECT_ACCOUNT_GUIDANCE}`
+              ? `Anonymous keyless access is unavailable for this request. To continue: ${CONNECT_ACCOUNT_GUIDANCE}`
               : isKeylessEligibilityUnavailable
                 ? 'The anonymous keyless eligibility check is temporarily unavailable. Retry shortly.'
               : 'This tool requires a Firecrawl account or API key. Connect an account or configure Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.',

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1108,15 +1108,24 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
     assert.equal(result.isError, true, label);
     assert.equal(result.structuredContent.code, expectedCode, label);
     // Interactive OAuth routes to the dedicated account resource, which is the
-    // only endpoint allowed to initiate sign-in. No client-specific command:
-    // this payload is advisory to the model, and the harness owns the flow.
+    // only endpoint allowed to initiate sign-in, and it replaces the entry the
+    // client already has rather than adding a second one. No client-specific
+    // command: this is advisory to the model, and the harness owns the flow.
     assert.deepEqual(result.structuredContent.next_actions[0], {
       kind: 'connect_via_oauth',
       url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+      requires_user_consent: true,
+      replace_current_server: true,
     }, label);
-    // Conversion needs a human, so the copy routes the choice to the user
-    // rather than handing the agent something to run on its own.
-    assert.match(result.structuredContent.message, /ask the user to connect/i, label);
+    // Retargeting mutates client config, so consent comes first and the copy
+    // must say to repoint the existing entry rather than register another.
+    assert.match(result.structuredContent.message, /Ask the user first/, label);
+    assert.match(result.structuredContent.message, /replace this Firecrawl server's URL/, label);
+    assert.match(
+      result.structuredContent.message,
+      /Do not modify MCP configuration before consent/,
+      label
+    );
     if (label === 'with-reason') {
       assert.equal(result.structuredContent.retry_after_seconds, 42);
       // The countdown is the live Redis TTL, so the copy interpolates it

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1026,7 +1026,7 @@ test('HTTP cloud keyless returns retry recovery when eligibility is unavailable'
     { kind: 'retry_later', after_seconds: 30 },
   ]);
   assert.equal(
-    result.structuredContent.available_tools.includes('firecrawl_search'),
+    result.structuredContent.keyless_tools.includes('firecrawl_search'),
     true
   );
   assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
@@ -1064,7 +1064,7 @@ test('HTTP cloud keyless continues with free-tier tools when an account-only too
       tools: ['firecrawl_scrape', 'firecrawl_search', 'firecrawl_parse'],
     },
   ]);
-  assert.deepEqual(result.structuredContent.available_tools, [
+  assert.deepEqual(result.structuredContent.keyless_tools, [
     'firecrawl_scrape',
     'firecrawl_search',
     'firecrawl_parse',
@@ -1107,8 +1107,22 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
     const result = parseSseJson(await response.text()).result;
     assert.equal(result.isError, true, label);
     assert.equal(result.structuredContent.code, expectedCode, label);
-    assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth', label);
-    if (label === 'with-reason') assert.equal(result.structuredContent.retry_after_seconds, 42);
+    // Interactive OAuth routes to the dedicated account resource, which is the
+    // only endpoint allowed to initiate sign-in. No client-specific command:
+    // this payload is advisory to the model, and the harness owns the flow.
+    assert.deepEqual(result.structuredContent.next_actions[0], {
+      kind: 'connect_via_oauth',
+      url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+    }, label);
+    // Conversion needs a human, so the copy routes the choice to the user
+    // rather than handing the agent something to run on its own.
+    assert.match(result.structuredContent.message, /ask the user to connect/i, label);
+    if (label === 'with-reason') {
+      assert.equal(result.structuredContent.retry_after_seconds, 42);
+      // The countdown is the live Redis TTL, so the copy interpolates it
+      // instead of quoting a fixed window.
+      assert.match(result.structuredContent.message, /about 42 seconds/);
+    }
     await cleanup();
   }
 });
@@ -1271,8 +1285,8 @@ test('HTTP cloud keyless rejects multi-hop or malformed forwarded IP identity', 
     const result = parseSseJson(await response.text()).result;
     assert.equal(result.isError, true, xff);
     assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE', xff);
-    assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth', xff);
-    assert.equal(result.structuredContent.available_tools, undefined, xff);
+    assert.equal(result.structuredContent.next_actions[0].kind, 'connect_via_oauth', xff);
+    assert.equal(result.structuredContent.keyless_tools, undefined, xff);
   }
   assert.equal(backend.requests.length, 0, JSON.stringify(backend.requests));
 });
@@ -1424,8 +1438,8 @@ test('HTTP cloud transport returns recovery when keyless identity has no client 
   const result = parseSseJson(await toolCall.text()).result;
   assert.equal(result.isError, true);
   assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE');
-  assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth');
-  assert.equal(result.structuredContent.available_tools, undefined);
+  assert.equal(result.structuredContent.next_actions[0].kind, 'connect_via_oauth');
+  assert.equal(result.structuredContent.keyless_tools, undefined);
   assertServerGeneratedRequestId(result.structuredContent, [
     'client-json-rpc-id',
     'client-request-header-id',


### PR DESCRIPTION
## Why

When a keyless session hits the free limit, the recovery payload hands the agent a runnable command:

```
claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth
```

Nothing in the payload marks the human step, so an agent can start conversion on its own. The intended sequence is: keyless hits the wall, the agent asks the user, the user agrees, then the client's own auth flow runs and the agent retries.

The payload cannot force that. It is advisory to the model, not a protocol signal a client interprets, and nothing in it opens a browser. What it can do is put the choice to a human and name where to go. That is what this PR changes.

### Routing is unchanged, and that is deliberate

Interactive OAuth stays on `/v2/mcp-oauth`. Per the accepted design and [connect.mdx](https://docs.firecrawl.dev/mcp-server/connect):

> New interactive account connections should use `/v2/mcp-oauth`; new tokens for that account resource are not accepted by `/v2/mcp`.

`/v2/mcp` accepts API keys and OAuth tokens already bound to it, but never initiates sign-in, and only the explicitly OAuth endpoint is allowed to. The same-URL upgrade from keyless is the API key, not new OAuth. Verified live: anon `POST /v2/mcp` returns `200`, anon `POST /v2/mcp-oauth` returns `401` with `WWW-Authenticate`. A keyless quota failure still stays in-band as `200` + `isError` rather than becoming a `401`.

## Summary

- Dropped `client_commands`. The consent step now lives in the message: "ask the user to connect a Firecrawl account via OAuth or configure an API key." Removing the runnable command is what stops an agent self-converting, and it keeps the payload harness-agnostic.
- Renamed `available_tools` to `keyless_tools`, which says what the list actually is.
- Renamed `connect_oauth` to `connect_via_oauth`, which does not read as something the agent executes.
- Tightened the limit copy: "The free daily limit has been reached; try again in about N seconds. To continue with higher limits now, ..."

Unchanged: `connect_via_oauth.url` still points at `https://mcp.firecrawl.dev/v2/mcp-oauth`, `retry_after_seconds` is still the live Redis TTL and still interpolated into the copy, and `configure_api_key`, `docs_url`, `request_id`, `auth_mode`, `retry_later`, and `continue_keyless` are untouched. `KEYLESS_TOOL_NOT_AVAILABLE` still returns `continue_keyless` with no upsell.

### Before

```json
{
  "code": "KEYLESS_QUOTA_EXHAUSTED",
  "message": "The free daily limit for this network has been reached; try again in about 48213 seconds. To continue now, connect a Firecrawl account via OAuth or configure an API key.",
  "available_tools": ["firecrawl_scrape", "firecrawl_search", "firecrawl_parse"],
  "retry_after_seconds": 48213,
  "next_actions": [
    {
      "kind": "connect_oauth",
      "url": "https://mcp.firecrawl.dev/v2/mcp-oauth",
      "client_commands": [
        { "client": "claude-code", "command": "claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth" }
      ]
    },
    { "kind": "configure_api_key", "header": "Authorization: Bearer <FIRECRAWL_API_KEY>" }
  ]
}
```

### After

```json
{
  "code": "KEYLESS_QUOTA_EXHAUSTED",
  "request_id": "<uuid>",
  "auth_mode": "keyless",
  "message": "The free daily limit has been reached; try again in about 48213 seconds. To continue with higher limits now, ask the user to connect a Firecrawl account via OAuth or configure an API key.",
  "keyless_tools": ["firecrawl_scrape", "firecrawl_search", "firecrawl_parse"],
  "docs_url": "https://docs.firecrawl.dev/mcp-server",
  "retry_after_seconds": 48213,
  "next_actions": [
    { "kind": "connect_via_oauth", "url": "https://mcp.firecrawl.dev/v2/mcp-oauth" },
    { "kind": "configure_api_key", "header": "Authorization: Bearer <FIRECRAWL_API_KEY>" }
  ]
}
```

## Test Plan

- `HTTP cloud keyless keeps 429 recovery structured during API deploy skew` extended to assert `next_actions[0]` by deep equality (`connect_via_oauth` at the account resource, no client command), that the copy routes the choice to the user, and that the live TTL is interpolated rather than frozen. Passes.
- Captured the real payload for all seven recovery codes from a spawned server against a fake API and diffed against `origin/main`. Only the intended fields moved; `retry_later` and `continue_keyless` are byte-identical.
- Live-checked production for the endpoint split above.
- `npx eslint src/index.ts` clean.
- Pre-existing on `origin/main` in this checkout and unaffected by this change: three `canList` tool-filtering tests fail because the locally installed `fastmcp` is not the patched build. Verified identical failures with the branch stashed.

## Separate docs bug found while verifying

`connect.mdx` prescribes this command for the free-limit case:

```bash
claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth
```

It cannot work in the scenario it is given for. A user who hit the keyless wall got there because they already have a server named `firecrawl` at `/v2/mcp`, which is what the same page's "Try keyless" section tells them to add. Reproduced:

```
$ claude mcp add --scope project --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp
Added HTTP MCP server firecrawl ...
$ claude mcp add --scope project --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth
MCP server firecrawl already exists in .mcp.json      # exit 1, config unchanged
```

A distinct name works (`firecrawl-account`, exit 0), at the cost of a duplicated tool surface. Not fixed here since this PR removes the command from the payload, but the docs still ship it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788568087&installation_model_id=11126&pr_number=354&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F354&signature=521b4ee57e5aca7fc5b5022badccc4fad897ce5211b80f6916d117052860af3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves keyless recovery behind a human decision and clarifies that OAuth conversion should retarget the existing server entry instead of adding a new one. Removes runnable commands and keeps interactive OAuth on `/v2/mcp-oauth`.

- **Bug Fixes**
  - Conversion requires a human decision; the message tells the agent to ask the user and to repoint the current server (same name/scope), not register another.
  - Removed runnable `client_commands` to prevent agent self-conversion.
  - OAuth action targets `/v2/mcp-oauth`; `/v2/mcp` never initiates sign-in.
  - Tightened message copy; TTL remains interpolated.

- **Migration**
  - `available_tools` -> `keyless_tools`.
  - `connect_oauth` -> `connect_via_oauth`; action now includes `requires_user_consent` and `replace_current_server` when retargeting is needed.
  - Recovery payload no longer includes `client_commands`.

<sup>Written for commit ace00c7eb53c4b2d4bed0a522bd5886697e6128f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

