### PR TITLE
fix(mcp): reject invalid header credentials at connect time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.23.3",
+  "version": "3.23.4",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.firecrawl/firecrawl-mcp-server",
   "title": "Firecrawl MCP Server",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web.",
-  "version": "3.23.3",
+  "version": "3.23.4",
   "repository": {
     "url": "https://github.com/firecrawl/firecrawl-mcp-server.git",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "firecrawl-mcp",
-      "version": "3.23.3",
+      "version": "3.23.4",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -491,18 +491,12 @@ async function authenticateRequest(
   if (process.env.CLOUD_SERVICE === 'true') {
     if (!headerCred && !managedCred) {
       if (resolved?.invalid) {
-        if (!profile.acceptApiKeys) {
-          throw new Error(
-            `OAuth access token required for the Firecrawl MCP resource ${profile.endpoint}`
-          );
-        }
-        // The credential-in-path compatibility route is the only legacy shape
-        // that must fail at connection time. Header clients keep their existing
-        // recovery payload contract while this compatibility fix stays narrow.
-        if (isLegacyKeyPathRequest(request)) {
-          throw new InvalidFirecrawlCredentialError();
-        }
-        return { authType: 'none', credentialError: 'CREDENTIAL_INVALID' };
+        // A supplied credential must never silently downgrade a hosted session
+        // to an empty tool list. MCP clients commonly stop after tools/list, so
+        // the old in-band recovery payload was unreachable for invalid header
+        // credentials. Keep unauthenticated requests on the keyless path; only
+        // reject requests that actually supplied an invalid credential.
+        throw new InvalidFirecrawlCredentialError();
       }
       if (profile.allowKeyless) {
         return {

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -486,16 +486,24 @@ test('search surface requires authentication for tools/list', async (t) => {
   assert.match(wwwAuthenticate, /error="invalid_token"/);
 });
 
-test('search surface hides tools from an invalid credential', async (t) => {
+test('search surface rejects an invalid raw API credential during tools/list', async (t) => {
   const { searchPort } = await startHostedServer(t);
 
-  const names = await listTools(searchPort, SEARCH_ENDPOINT, {
-    'x-api-key': 'fc-invalid',
+  const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 8,
+    method: 'tools/list',
+    headers: { 'x-api-key': 'fc-invalid' },
   });
-  assert.deepEqual(names, []);
+  assert.equal(res.status, 401);
+  assert.equal(res.headers.has('www-authenticate'), false);
+  assert.deepEqual(await res.json(), {
+    error: 'invalid_api_key',
+    error_description:
+      'The supplied Firecrawl credential is invalid or revoked. Replace it and retry.',
+  });
 });
 
-test('search surface returns structured recovery for an invalid credential', async (t) => {
+test('search surface rejects an invalid raw API credential before a tool call', async (t) => {
   const backend = await startFakeBackend();
   t.after(() => backend.close());
   const { searchPort } = await startHostedServer(t, {
@@ -511,14 +519,13 @@ test('search surface returns structured recovery for an invalid credential', asy
     },
     headers: { 'x-api-key': 'fc-invalid' },
   });
-  assert.equal(res.status, 200);
-  const message = parseSseJson(await res.text());
-  assert.equal(message.result?.isError, true, JSON.stringify(message));
-  assert.equal(
-    message.result?.structuredContent?.code,
-    'CREDENTIAL_INVALID',
-    JSON.stringify(message)
-  );
+  assert.equal(res.status, 401);
+  assert.equal(res.headers.has('www-authenticate'), false);
+  assert.deepEqual(await res.json(), {
+    error: 'invalid_api_key',
+    error_description:
+      'The supplied Firecrawl credential is invalid or revoked. Replace it and retry.',
+  });
   assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
 });
 
@@ -863,9 +870,12 @@ test('companion telemetry follows credential precedence and rejects invalid cred
     authorization: 'Bearer fco_secondary-credential',
     'x-api-key': 'fc-primary-credential',
   });
-  await listTools(searchPort, SEARCH_ENDPOINT, {
-    authorization: 'Bearer fc-invalid-credential',
+  const invalid = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 12,
+    method: 'tools/list',
+    headers: { authorization: 'Bearer fc-invalid-credential' },
   });
+  assert.equal(invalid.status, 401);
   await delay(25);
 
   const events = getStdout()

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1880,8 +1880,13 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
     },
     method: 'POST',
   });
-  assert.equal(invalidList.status, 200);
-  assert.deepEqual(parseSseJson(await invalidList.text()).result.tools, []);
+  assert.equal(invalidList.status, 401);
+  assert.equal(invalidList.headers.has('www-authenticate'), false);
+  assert.deepEqual(await invalidList.json(), {
+    error: 'invalid_api_key',
+    error_description:
+      'The supplied Firecrawl credential is invalid or revoked. Replace it and retry.',
+  });
 
   const invalidCall = await httpToolCall(port, {
     headers: {
@@ -1891,14 +1896,13 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
     id: 3,
     params: { arguments: { query: 'x' }, name: 'firecrawl_search' },
   });
-  assert.equal(invalidCall.status, 200);
-  const result = parseSseJson(await invalidCall.text()).result;
-  assert.equal(result.isError, true);
-  assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID');
-  assertServerGeneratedRequestId(result.structuredContent, [
-    3,
-    'invalid-client-request-header-id',
-  ]);
+  assert.equal(invalidCall.status, 401);
+  assert.equal(invalidCall.headers.has('www-authenticate'), false);
+  assert.deepEqual(await invalidCall.json(), {
+    error: 'invalid_api_key',
+    error_description:
+      'The supplied Firecrawl credential is invalid or revoked. Replace it and retry.',
+  });
 
   const invalidLegacyPath = await fetch(`http://127.0.0.1:${port}/v2/mcp`, {
     body: JSON.stringify({ id: 4, jsonrpc: '2.0', method: 'tools/list', params: {} }),


### PR DESCRIPTION
## Summary
Reject invalid supplied API-key/header credentials with `401 invalid_api_key` during MCP connection setup.

Previously, an invalid header caused `tools/list` to return `200` with an empty tool array; clients then had no tool call through which to receive recovery guidance. Credential-less keyless sessions remain unchanged.

## Validation
- `npm run lint`
- `npm test` (65/65 passing)

## Compatibility
This is intentionally a raw invalid-key response without `WWW-Authenticate`: invalid supplied credentials should be replaced or removed rather than automatically triggering an OAuth challenge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788594664&installation_model_id=11126&pr_number=358&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F358&signature=58294ef9c507e07577d2c00a07feeab6f3ee9f2b5dde6603f3682911465283f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject invalid header credentials during MCP connect by returning 401 with `invalid_api_key`. This prevents the empty tools list on bad headers and keeps keyless sessions unchanged.

- **Bug Fixes**
  - Validate `x-api-key`/Authorization at connect time and return 401 JSON `{ error: 'invalid_api_key' }` without `WWW-Authenticate`.
  - Stop silently downgrading hosted sessions; invalid headers no longer yield an empty `tools/list`.

- **Dependencies**
  - Bump `firecrawl-mcp` to `3.23.4` and update `server.json` metadata.

<sup>Written for commit b0f88726db5a3b08419506c55abebb8f9ff88e1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

