### PR TITLE
fix(mcp): hide deprecated Extract and provide migration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Connect to the remote hosted server with no setup:
 https://mcp.firecrawl.dev/v2/mcp
 ```
 
-On the keyless free tier, `scrape`, `search`, and `interact` work without an API key (rate-limited). Other tools such as `crawl`, `map`, `agent`, and `extract` still need a key.
+On the keyless free tier, `scrape`, `search`, and `interact` work without an API key (rate-limited). Other tools such as `crawl`, `map`, and `agent` still need a key.
 
 Prefer OAuth or an API key whenever the human can sign up. It unlocks the full tool set and higher limits.
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,6 @@ Use this guide to select the right tool for your task:
 | map          | Discovering URLs on a site                     | URL[]                          |
 | crawl        | Multi-page extraction (with limits)            | final crawl status/data after internal polling |
 | parse        | Files and hosted upload refs                   | markdown, JSON, or document output |
-| extract      | Structured extraction from URLs                | JSON structured data           |
 | search       | Web search for info                            | results[]                      |
 | developer    | Programming questions over developer sources   | results[] with passages        |
 | agent        | Complex multi-source research                  | JSON (structured data)         |
@@ -657,78 +656,33 @@ Parse local files or hosted upload references with Firecrawl's `/v2/parse` endpo
 
 **Returns:** Parsed document content or hosted upload instructions with a `nextToolCall`.
 
-### 7. Extract Tool (`firecrawl_extract`)
+### 7. Structured data with Scrape JSON
 
-Extract structured information from web pages using LLM capabilities. Supports both cloud AI and self-hosted LLM extraction.
-
-**Best for:**
-
-- Extracting specific structured data like prices, names, details.
-
-**Not recommended for:**
-
-- When you need the full content of a page (use scrape)
-- When you're not looking for specific structured data
-
-**Arguments:**
-
-- `urls`: Array of URLs to extract information from
-- `prompt`: Custom prompt for the LLM extraction
-- `systemPrompt`: System prompt to guide the LLM
-- `schema`: JSON schema for structured data extraction
-- `allowExternalLinks`: Allow extraction from external links
-- `enableWebSearch`: Enable web search for additional context
-- `includeSubdomains`: Include subdomains in extraction
-
-When using a self-hosted instance, the extraction will use your configured LLM. For cloud API, it uses Firecrawl's managed LLM service.
-**Prompt Example:**
-
-> "Extract the product name, price, and description from these product pages."
-
-**Usage Example:**
+For structured data from a known page, call `firecrawl_scrape` once per URL with `formats: ["json"]`. Put the extraction prompt and JSON schema in `jsonOptions`.
 
 ```json
 {
-  "name": "firecrawl_extract",
+  "name": "firecrawl_scrape",
   "arguments": {
-    "urls": ["https://example.com/page1", "https://example.com/page2"],
-    "prompt": "Extract product information including name, price, and description",
-    "systemPrompt": "You are a helpful assistant that extracts product information",
-    "schema": {
-      "type": "object",
-      "properties": {
-        "name": { "type": "string" },
-        "price": { "type": "number" },
-        "description": { "type": "string" }
-      },
-      "required": ["name", "price"]
-    },
-    "allowExternalLinks": false,
-    "enableWebSearch": false,
-    "includeSubdomains": false
+    "url": "https://example.com/product",
+    "formats": ["json"],
+    "jsonOptions": {
+      "prompt": "Extract the product name, price, and description.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "price": { "type": "number" },
+          "description": { "type": "string" }
+        },
+        "required": ["name", "price"]
+      }
+    }
   }
 }
 ```
 
-**Returns:**
-
-- Extracted structured data as defined by your schema
-
-```json
-{
-  "content": [
-    {
-      "type": "text",
-      "text": {
-        "name": "Example Product",
-        "price": 99.99,
-        "description": "This is an example product description"
-      }
-    }
-  ],
-  "isError": false
-}
-```
+For unknown URLs or multi-source research, use `firecrawl_search` or `firecrawl_agent` before Scrape.
 
 ### 8. Agent Tool (`firecrawl_agent`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.23.5",
+  "version": "3.23.6",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.firecrawl/firecrawl-mcp-server",
   "title": "Firecrawl MCP Server",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web.",
-  "version": "3.23.4",
+  "version": "3.23.6",
   "repository": {
     "url": "https://github.com/firecrawl/firecrawl-mcp-server.git",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "firecrawl-mcp",
-      "version": "3.23.4",
+      "version": "3.23.6",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2626,8 +2626,16 @@ Deprecated compatibility entry point. Use firecrawl_scrape once per known URL wi
     includeSubdomains: z.boolean().optional(),
   }),
   canList: () => false,
-  beforeValidate: () => {
+  beforeValidate: (_args: unknown, session: SessionData) => {
     const payload = deprecatedExtractPayload();
+    emitActionLog(
+      'firecrawl_extract',
+      'error',
+      session,
+      new UserError(payload.message, payload),
+      randomUUID(),
+      'DEPRECATED_TOOL'
+    );
     return {
       content: [{ type: 'text' as const, text: payload.message }],
       isError: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1091,7 +1091,7 @@ function guardHostedTool(
       !session?.credentialError &&
       (!isHostedKeylessSession(session) || keylessTool) &&
       (canList?.(session) ?? true),
-    beforeValidate: (args: unknown, session: SessionData) => {
+    beforeValidate: async (args: unknown, session: SessionData) => {
       const code = session?.credentialError
         ? 'CREDENTIAL_INVALID'
         : isHostedKeylessSession(session) && !keylessTool
@@ -1109,7 +1109,26 @@ function guardHostedTool(
           structuredContent: payload,
         };
       }
-      return beforeValidate?.(args, session);
+      const earlyResult = await beforeValidate?.(args, session);
+      const payload = earlyResult?.structuredContent;
+      const recoveryCode =
+        payload &&
+        typeof payload === 'object' &&
+        'code' in payload &&
+        typeof payload.code === 'string'
+          ? payload.code
+          : undefined;
+      if (logActions && earlyResult?.isError && recoveryCode) {
+        emitActionLog(
+          tool.name,
+          'error',
+          session,
+          new UserError(`Tool validation failed: ${recoveryCode}`, payload),
+          randomUUID(),
+          recoveryCode
+        );
+      }
+      return earlyResult;
     },
     execute: async (args, context) => {
       const requestId = randomUUID();
@@ -2626,16 +2645,8 @@ Deprecated compatibility entry point. Use firecrawl_scrape once per known URL wi
     includeSubdomains: z.boolean().optional(),
   }),
   canList: () => false,
-  beforeValidate: (_args: unknown, session: SessionData) => {
+  beforeValidate: () => {
     const payload = deprecatedExtractPayload();
-    emitActionLog(
-      'firecrawl_extract',
-      'error',
-      session,
-      new UserError(payload.message, payload),
-      randomUUID(),
-      'DEPRECATED_TOOL'
-    );
     return {
       content: [{ type: 'text' as const, text: payload.message }],
       isError: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -821,8 +821,8 @@ const openAiAppsChallengeToken = normalizeHeader(
   process.env.OPENAI_APPS_CHALLENGE_TOKEN
 );
 
-const FULL_PROFILE_INSTRUCTIONS = `Firecrawl provides web search, page retrieval, site URL discovery, multi-page collection, structured extraction, monitoring, and asynchronous research. Match the requested operation to the tool boundary: firecrawl_scrape retrieves one supplied page, firecrawl_map enumerates URLs under a site without retrieving their content, and firecrawl_agent starts multi-source research whose result is read with firecrawl_agent_status. Provide only the required inputs and account for stated network or external side effects.`;
-const KEYLESS_PROFILE_INSTRUCTIONS = `Without authentication, this endpoint exposes Search, Scrape, and Parse with usage limits. An OAuth connection or Authorization bearer API key exposes account tools; unavailable tools return connection guidance. Firecrawl provides web search, page retrieval, site URL discovery, multi-page collection, structured extraction, monitoring, and asynchronous research. Match the requested operation to the tool boundary: firecrawl_scrape retrieves one supplied page, firecrawl_map enumerates URLs under a site without retrieving their content, and firecrawl_agent starts multi-source research whose result is read with firecrawl_agent_status. Provide only the required inputs.`;
+const FULL_PROFILE_INSTRUCTIONS = `Firecrawl provides web search, page retrieval, site URL discovery, multi-page collection, structured page data, monitoring, and asynchronous research. Match the requested operation to the tool boundary: firecrawl_scrape retrieves one supplied page and can return JSON matching a supplied schema, firecrawl_map enumerates URLs under a site without retrieving their content, and firecrawl_agent starts multi-source research whose result is read with firecrawl_agent_status. Provide only the required inputs and account for stated network or external side effects.`;
+const KEYLESS_PROFILE_INSTRUCTIONS = `Without authentication, this endpoint exposes Search, Scrape, and Parse with usage limits. An OAuth connection or Authorization bearer API key exposes account tools; unavailable tools return connection guidance. Firecrawl provides web search, page retrieval, site URL discovery, multi-page collection, structured page data, monitoring, and asynchronous research. Match the requested operation to the tool boundary: firecrawl_scrape retrieves one supplied page and can return JSON matching a supplied schema, firecrawl_map enumerates URLs under a site without retrieving their content, and firecrawl_agent starts multi-source research whose result is read with firecrawl_agent_status. Provide only the required inputs.`;
 
 // The search surface exposes web/research search only. Its instructions and tool
 // copy describe just those tools and stay neutral about how a client uses them.
@@ -1003,6 +1003,31 @@ function recoveryPayload(
           ],
   };
 }
+
+function deprecatedExtractPayload() {
+  return {
+    code: 'DEPRECATED_TOOL',
+    message:
+      'firecrawl_extract is deprecated and unavailable through MCP. For structured data from a known page, call firecrawl_scrape once per URL with formats: ["json"] and jsonOptions containing the prompt and schema. For unknown URLs or multi-source research, use firecrawl_search or firecrawl_agent first.',
+    replacement: {
+      name: 'firecrawl_scrape',
+      instructions:
+        'Call once per known URL. Set formats to ["json"] and pass the extraction prompt and JSON schema in jsonOptions.',
+      example_arguments: {
+        url: 'https://example.com/page',
+        formats: ['json'],
+        jsonOptions: {
+          prompt: 'Extract the requested fields from this page.',
+          schema: {
+            type: 'object',
+            properties: {},
+          },
+        },
+      },
+    },
+    docs_url: 'https://docs.firecrawl.dev/developer-guides/usage-guides/choosing-the-data-extractor',
+  };
+}
 type ActionStatus = 'started' | 'success' | 'error';
 
 function emitActionLog(
@@ -1058,28 +1083,33 @@ function guardHostedTool(
 ): RegisteredTool {
   const keylessTool = KEYLESS_TOOL_NAMES.has(tool.name);
   const execute = tool.execute;
+  const canList = tool.canList;
+  const beforeValidate = tool.beforeValidate;
   return {
     ...tool,
     canList: (session: SessionData) =>
       !session?.credentialError &&
-      (!isHostedKeylessSession(session) || keylessTool),
-    beforeValidate: (_args: unknown, session: SessionData) => {
+      (!isHostedKeylessSession(session) || keylessTool) &&
+      (canList?.(session) ?? true),
+    beforeValidate: (args: unknown, session: SessionData) => {
       const code = session?.credentialError
         ? 'CREDENTIAL_INVALID'
         : isHostedKeylessSession(session) && !keylessTool
           ? 'KEYLESS_TOOL_NOT_AVAILABLE'
           : undefined;
-      if (!code) return undefined;
-      const requestId = randomUUID();
-      const payload = recoveryPayload(code, requestId);
-      if (logActions) {
-        emitActionLog(tool.name, 'error', session, new UserError(String(payload.message), payload), requestId, code);
+      if (code) {
+        const requestId = randomUUID();
+        const payload = recoveryPayload(code, requestId);
+        if (logActions) {
+          emitActionLog(tool.name, 'error', session, new UserError(String(payload.message), payload), requestId, code);
+        }
+        return {
+          content: [{ type: 'text' as const, text: String(payload.message) }],
+          isError: true,
+          structuredContent: payload,
+        };
       }
-      return {
-        content: [{ type: 'text' as const, text: String(payload.message) }],
-        isError: true,
-        structuredContent: payload,
-      };
+      return beforeValidate?.(args, session);
     },
     execute: async (args, context) => {
       const requestId = randomUUID();
@@ -2579,15 +2609,13 @@ Retrieve the current status, progress, and available results for an existing cra
 server.addTool({
   name: 'firecrawl_extract',
   annotations: {
-    title: 'Extract structured data',
-    readOnlyHint: true, // Uses LLM extraction to pull structured data from URLs without modifying those sites.
-    openWorldHint: true, // Accepts arbitrary user-supplied URLs on the public web.
-    destructiveHint: false, // Read-only extraction; no destructive changes to external content.
+    title: 'Deprecated: use Scrape JSON',
+    readOnlyHint: true,
+    openWorldHint: true,
+    destructiveHint: false,
   },
   description: `
-Extract structured information from one or more URLs with an optional natural-language prompt and JSON schema. It can include subdomains, follow external links, or use web search when those options are enabled.
-
-Use this for a defined structured result rather than full page content. Returns data shaped by the supplied schema or prompt.
+Deprecated compatibility entry point. Use firecrawl_scrape once per known URL with formats: ["json"] and jsonOptions containing the prompt and schema. Use firecrawl_search or firecrawl_agent before Scrape when URLs are not known.
 `,
   parameters: z.object({
     urls: z.array(z.string()),
@@ -2597,23 +2625,18 @@ Use this for a defined structured result rather than full page content. Returns 
     enableWebSearch: z.boolean().optional(),
     includeSubdomains: z.boolean().optional(),
   }),
-  execute: async (args: unknown, { session, log }): Promise<string> => {
-    const client = getClient(session);
-    const a = args as Record<string, unknown>;
-    log.info('Extracting from URLs', {
-      count: Array.isArray(a.urls) ? a.urls.length : 0,
-    });
-    const extractBody = removeEmptyTopLevel({
-      urls: a.urls as string[],
-      prompt: a.prompt as string | undefined,
-      schema: (a.schema as Record<string, unknown>) || undefined,
-      allowExternalLinks: a.allowExternalLinks as boolean | undefined,
-      enableWebSearch: a.enableWebSearch as boolean | undefined,
-      includeSubdomains: a.includeSubdomains as boolean | undefined,
-      origin: ORIGIN,
-    });
-    const res = await client.extract(extractBody as any);
-    return asText(res);
+  canList: () => false,
+  beforeValidate: () => {
+    const payload = deprecatedExtractPayload();
+    return {
+      content: [{ type: 'text' as const, text: payload.message }],
+      isError: true,
+      structuredContent: payload,
+    };
+  },
+  execute: async (): Promise<string> => {
+    const payload = deprecatedExtractPayload();
+    throw new UserError(payload.message, payload);
   },
 });
 

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1750,6 +1750,20 @@ test('account endpoint accepts legacy OAuth one way and delegates managed keys',
   );
   assert.equal(monitorPayload.api_key, 'fc-managed-secret');
   assert.equal(monitorPayload.purpose, 'hosted_mcp_oauth');
+
+  const deprecatedExtractResponse = await httpToolCall(port, {
+    endpoint: '/v2/mcp-oauth',
+    headers: { authorization: 'Bearer fco_account' },
+    id: 'managed-deprecated-extract',
+    params: { arguments: {}, name: 'firecrawl_extract' },
+  });
+  assert.equal(deprecatedExtractResponse.status, 200);
+  const deprecatedExtractResult = parseSseJson(
+    await deprecatedExtractResponse.text()
+  ).result;
+  assert.equal(deprecatedExtractResult.isError, true);
+  assert.equal(deprecatedExtractResult.structuredContent.code, 'DEPRECATED_TOOL');
+
   const legacyAttempts = backend.requests
     .filter((request) => request.url === '/api/oauth/introspect')
     .filter((request) => request.body.token === 'fco_legacy')
@@ -1760,7 +1774,7 @@ test('account endpoint accepts legacy OAuth one way and delegates managed keys',
     if (
       backend.requests.filter(
         (request) => request.url === '/v2/mcp/action-logs'
-      ).length === 3
+      ).length === 4
     ) {
       break;
     }
@@ -1769,11 +1783,17 @@ test('account endpoint accepts legacy OAuth one way and delegates managed keys',
   const actionLogs = backend.requests.filter(
     (request) => request.url === '/v2/mcp/action-logs'
   );
-  assert.equal(actionLogs.length, 3);
+  assert.equal(actionLogs.length, 4);
+  const deprecatedExtractLog = actionLogs.find(
+    request => request.body.tool_name === 'firecrawl_extract'
+  );
+  assert.ok(deprecatedExtractLog);
+  assert.equal(deprecatedExtractLog.body.status, 'error');
+  assert.equal(deprecatedExtractLog.body.error_class, 'UserError');
+
   for (const request of actionLogs) {
     assert.equal(request.headers.authorization, 'Bearer action-secret');
     assert.equal(request.body.auth_type, 'oauth');
-    assert.equal(request.body.status, 'success');
     assert.equal(request.body.api_key_id, '42');
     assert.equal(request.body.team_id, metadata.team_id);
     assert.equal(request.body.user_id, metadata.sub);
@@ -1782,6 +1802,10 @@ test('account endpoint accepts legacy OAuth one way and delegates managed keys',
     assert.equal(JSON.stringify(request.body).includes('fc-managed-secret'), false);
     assert.equal(JSON.stringify(request.body).includes('fco_'), false);
   }
+  assert.equal(
+    actionLogs.filter(request => request.body.status === 'success').length,
+    3
+  );
   assert.equal(stderr.includes('fc-managed-secret'), false);
   assert.equal(stderr.includes('fco_account'), false);
   assert.equal(stderr.includes('fco_legacy'), false);

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -439,6 +439,18 @@ test('HTTP cloud transport preserves Firecrawl OAuth and well-known routes', asy
   assert.ok(httpToolNames.includes('firecrawl_scrape'));
   assert.ok(httpToolNames.includes('firecrawl_search'));
   assert.ok(httpToolNames.includes('firecrawl_parse'));
+  assert.equal(httpToolNames.includes('firecrawl_extract'), false);
+
+  const deprecatedExtract = await httpToolCall(port, {
+    id: 31,
+    headers: { 'x-api-key': 'fc-test' },
+    params: { arguments: {}, name: 'firecrawl_extract' },
+  });
+  assert.equal(deprecatedExtract.status, 200);
+  const deprecatedExtractMessage = parseSseJson(await deprecatedExtract.text()).result;
+  assert.equal(deprecatedExtractMessage.isError, true);
+  assert.equal(deprecatedExtractMessage.structuredContent.code, 'DEPRECATED_TOOL');
+
   const searchTool = toolsMessage.result.tools.find(
     (tool) => tool.name === 'firecrawl_search'
   );
@@ -609,6 +621,23 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   assert.ok(toolNames.includes('firecrawl_scrape'));
   assert.ok(toolNames.includes('firecrawl_search'));
   assert.ok(toolNames.includes('firecrawl_parse'));
+  assert.equal(toolNames.includes('firecrawl_extract'), false);
+
+  const deprecatedExtract = await client.request('tools/call', {
+    // beforeValidate must intercept before the legacy required `urls` schema.
+    arguments: {},
+    name: 'firecrawl_extract',
+  });
+  assert.equal(deprecatedExtract.isError, true);
+  assert.equal(deprecatedExtract.structuredContent.code, 'DEPRECATED_TOOL');
+  assert.equal(
+    deprecatedExtract.structuredContent.replacement.name,
+    'firecrawl_scrape'
+  );
+  assert.deepEqual(
+    deprecatedExtract.structuredContent.replacement.example_arguments.formats,
+    ['json']
+  );
 
   const byName = new Map(tools.tools.map((tool) => [tool.name, tool]));
   assert.match(init.instructions, /firecrawl_scrape retrieves one supplied page/i);


### PR DESCRIPTION
## Summary

- Hide deprecated `firecrawl_extract` from MCP tool discovery and return structured migration guidance for direct or cached calls.
- Route known, single-page structured extraction to `firecrawl_scrape` JSON mode; recommend Search or Agent first only when URLs are unknown or research spans sources.
- Preserve tool-defined `canList` and `beforeValidate` hooks when hosted guards are composed.
- Update MCP documentation and add stdio + authenticated hosted-MCP regression coverage, including malformed legacy arguments.

## Intent and non-goal

This is a deprecation, cost, and tool-selection change. **It does not fix hallucinated extraction data.** Scrape JSON grounding and provenance need separate API work and should not be represented as resolved by this PR.

## Breaking change / rollout decision

Authenticated MCP clients using `firecrawl_extract` (including cached tool calls) will receive a terminal `DEPRECATED_TOOL` response with replacement instructions.

Production Firebrain data for Aug 1–7 shows 16,123 MCP-origin Extract calls across **3,490 distinct teams**. Mean Extract cost was **46.2 credits/call** (median 33; max 412). The known-page replacement is Scrape JSON at 5 credits/page—not the 1-credit markdown-only baseline—so the relevant expected cost comparison is about 9× lower, subject to workload shape.

## Known migration limitation

`/extract` can optionally return source mappings through `showSources`; Scrape JSON has no equivalent provenance option in its format schema. This migration therefore reduces output inspectability for callers that relied on Extract sources. That is an explicit follow-up requirement, not an implicit quality claim.

## Validation

- `npm test` — 66 passed
- `npm run lint` — passed
- `git diff --check` — passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788726863&installation_model_id=11126&pr_number=361&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F361&signature=f9b756d7f977d5712d61bdc33a732bf4c678fc4f7f9268cd84de677c3b89b283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide deprecated `firecrawl_extract` from MCP tool discovery and return a structured `DEPRECATED_TOOL` that points to Scrape JSON; deprecated and other early validation failures now emit error action logs. Also bumps `firecrawl-mcp` and registry metadata to 3.23.6.

- **Refactors**
  - `firecrawl_extract` no longer lists; `beforeValidate` returns a `DEPRECATED_TOOL` with a `firecrawl_scrape` JSON example and docs link, and `execute` throws the same payload; calls are action-logged as errors.
  - Hosted guard composes tool `canList`/`beforeValidate` and honors the action logging profile for early failures (credential/keyless blocks and tool-defined errors).
  - Updated profile instructions and README to center Scrape JSON; expanded HTTP/stdio tests for deprecation and early-error logging.

- **Migration**
  - For known URLs, call `firecrawl_scrape` with `formats: ["json"]` and put your prompt and JSON `schema` in `jsonOptions` (one call per URL).
  - For unknown URLs or multi-source work, use `firecrawl_search` or `firecrawl_agent` before Scrape.
  - `showSources` provenance from `/extract` is not available in Scrape JSON yet.

<sup>Written for commit 9564fa0475284ada375c787af366773bd174bbbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

