### PR TITLE
fix(mcp): make keyless recovery consent-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Connect to the remote hosted server with no setup:
 https://mcp.firecrawl.dev/v2/mcp
 ```
 
-On the keyless free tier, `scrape`, `search`, and `interact` work without an API key (rate-limited). Other tools such as `crawl`, `map`, and `agent` still need a key.
+On the keyless free tier, `scrape`, `search`, and `parse` work without an API key (rate-limited). Other tools such as `crawl`, `map`, and `agent` still need a key.
 
 Prefer OAuth or an API key whenever the human can sign up. It unlocks the full tool set and higher limits.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ On the keyless free tier, `scrape`, `search`, and `interact` work without an API
 
 Prefer OAuth or an API key whenever the human can sign up. It unlocks the full tool set and higher limits.
 
-For an interactive account connection, use:
+For an interactive account connection, configure your MCP client to use this server URL. This is an MCP endpoint, **not a browser page**; use the client's account-connection flow and do not add a second Firecrawl server entry when reconnecting:
 
 ```
 https://mcp.firecrawl.dev/v2/mcp-oauth
@@ -57,7 +57,7 @@ Then configure the client's secure header or secret setting with:
 Authorization: Bearer <FIRECRAWL_API_KEY>
 ```
 
-Never put an API key in the server URL. See the [hosted MCP setup guide](https://docs.firecrawl.dev/developer-guides/mcp-setup-guides/oauth) and the [agent onboarding guide](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for client-specific instructions.
+Never put an API key in the server URL. Never put an API key in an agent chat. Configure it directly in the client or secret manager. See the [hosted MCP setup guide](https://docs.firecrawl.dev/mcp-server) and the [agent onboarding guide](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for client-specific instructions.
 
 #### Search-only endpoint
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.23.6",
+  "version": "3.23.7",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",

--- a/src/index.ts
+++ b/src/index.ts
@@ -969,9 +969,10 @@ function isLocalKeylessStartup(): boolean {
 const MCP_CONNECTION_GUIDE_URL =
   'https://docs.firecrawl.dev/mcp-server';
 const MCP_OAUTH_SERVER_URL = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
+const API_KEY_SIGNUP_URL = 'https://www.firecrawl.dev/app/api-keys';
 
 const HUMAN_CONNECTION_GUIDANCE =
-  `This session cannot reconnect Firecrawl itself. Ask the human to choose before changing anything: (1) in the MCP client's settings, update or replace the existing Firecrawl server entry so its URL is ${MCP_OAUTH_SERVER_URL}, then complete sign-in through the client. That URL is a client configuration value, not a page to open in a browser. Do not add a second Firecrawl server or change configuration without approval; or (2) have an operator configure an API key in the client or secret manager outside this chat. Never ask for, accept, or put an API key in chat or in an MCP URL. After the human confirms setup, start a new client session or run and retry the original task. Connection guide: ${MCP_CONNECTION_GUIDE_URL}`;
+  `A human or operator must complete the connection because this session cannot reconnect Firecrawl itself. Ask the human to choose before changing anything: (1) in the MCP client's settings, update or replace the existing Firecrawl server entry so its URL is ${MCP_OAUTH_SERVER_URL}, then complete sign-in through the client. That URL is a client configuration value, not a page to open in a browser. Do not add a second Firecrawl server or change configuration without approval; or (2) have an operator create an API key at ${API_KEY_SIGNUP_URL} and configure it in the client or secret manager outside this chat. Never ask for, accept, or put an API key in chat or in an MCP URL. After the human confirms setup, start a new client session or run and retry the original task. Connection guide: ${MCP_CONNECTION_GUIDE_URL}`;
 
 const HUMAN_CONNECTION_ACTIONS = [
   {
@@ -988,6 +989,7 @@ const HUMAN_CONNECTION_ACTIONS = [
     actor: 'human_or_operator',
     requires_user_consent: true,
     credential_delivery: 'outside_agent_chat',
+    signup_url: API_KEY_SIGNUP_URL,
   },
 ] as const;
 
@@ -1011,11 +1013,11 @@ function recoveryPayload(
       code === 'CREDENTIAL_INVALID'
         ? `The supplied Firecrawl credential is invalid or revoked. ${HUMAN_CONNECTION_GUIDANCE}`
         : isQuotaExhausted
-          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now, ${HUMAN_CONNECTION_GUIDANCE}`
+          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now: ${HUMAN_CONNECTION_GUIDANCE}`
           : isToolUnavailable
-            ? 'The free tier includes Search, Scrape, and Parse. This tool needs a connected account; Search, Scrape, and Parse still work, so no action is required.'
+            ? `The free tier includes Search, Scrape, and Parse. This tool needs a connected account; those keyless tools still work. To use this tool: ${HUMAN_CONNECTION_GUIDANCE}`
             : isKeylessAccessUnavailable
-              ? `Anonymous keyless access is unavailable for this request. To continue, ${HUMAN_CONNECTION_GUIDANCE}`
+              ? `Anonymous keyless access is unavailable for this request. To continue: ${HUMAN_CONNECTION_GUIDANCE}`
               : isKeylessEligibilityUnavailable
                 ? 'The anonymous keyless eligibility check is temporarily unavailable. Retry shortly.'
               : `This tool requires a Firecrawl account or API key. ${HUMAN_CONNECTION_GUIDANCE}`,
@@ -1029,7 +1031,10 @@ function recoveryPayload(
       : isQuotaExhausted || isKeylessAccessUnavailable
       ? HUMAN_CONNECTION_ACTIONS
       : isToolUnavailable
-        ? [{ kind: 'continue_keyless', tools: [...KEYLESS_TOOL_NAMES] }]
+        ? [
+            { kind: 'continue_keyless', tools: [...KEYLESS_TOOL_NAMES] },
+            ...HUMAN_CONNECTION_ACTIONS,
+          ]
         : [
             ...HUMAN_CONNECTION_ACTIONS,
           ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { registerDeveloperTools } from './developer';
 import { extractSingleTrustedClientIp } from './keyless-client-ip';
 import { registerMonitorTools } from './monitor';
 import { registerResearchTools } from './research';
+import { escapeWWWAuthenticateValue } from './www-authenticate';
 import {
   credentialForOutboundRequest,
   copyManagedOAuthApiKey,
@@ -225,10 +226,6 @@ function getOAuthProtectedResourceMetadataUrl(profile: ServerProfile): string {
   return profile.id === 'full' ? base : `${base}${resource.pathname}`;
 }
 
-function escapeWWWAuthenticateValue(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-}
-
 function createOAuthChallengeResponse(
   error: unknown,
   profile: ServerProfile,
@@ -271,6 +268,22 @@ function createInvalidCredentialResponse(_error: InvalidFirecrawlCredentialError
   return new Response(
     JSON.stringify({
       error: 'invalid_api_key',
+      error_description: recovery.message,
+      ...recovery,
+    }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+      status: 401,
+    }
+  );
+}
+
+function createInvalidOAuthRecoveryResponse(
+  recovery: Record<string, unknown> & { message: string }
+): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'invalid_token',
       error_description: recovery.message,
       ...recovery,
     }),
@@ -687,7 +700,7 @@ function makeAuthenticate(profile: ServerProfile) {
             profile,
             recovery
           );
-          if (oauthChallenge) throw oauthChallenge;
+          throw oauthChallenge ?? createInvalidOAuthRecoveryResponse(recovery);
         }
         if (error instanceof CredentialValidationUnavailableError) {
           throw new Response(
@@ -994,6 +1007,9 @@ const API_KEY_SIGNUP_URL = 'https://www.firecrawl.dev/app/api-keys';
 const HUMAN_CONNECTION_GUIDANCE =
   `A human or operator must complete the connection because this session cannot reconnect Firecrawl itself. Ask the human to choose before changing anything: (1) in the MCP client's settings, update or replace the existing Firecrawl server entry so its URL is ${MCP_OAUTH_SERVER_URL}, then complete sign-in through the client. That URL is a client configuration value, not a page to open in a browser. Do not add a second Firecrawl server or change configuration without approval; or (2) have an operator create an API key at ${API_KEY_SIGNUP_URL} and configure it in the client or secret manager outside this chat. Never ask for, accept, or put an API key in chat or in an MCP URL. After the human confirms setup, start a new client session or run and retry the original task. Connection guide: ${MCP_CONNECTION_GUIDE_URL}`;
 
+const ACCOUNT_ONLY_TOOL_GUIDANCE =
+  `This tool needs a connected Firecrawl account. Search, Scrape, and Parse remain available, so continue with those if they can complete the task. Only if this task specifically requires this tool, tell the user that a human must update the existing Firecrawl connection using ${MCP_CONNECTION_GUIDE_URL}. Never ask for or accept an API key in chat. After setup, start a new client session and retry.`;
+
 const HUMAN_RECONNECT_ACCOUNT_ACTION = {
   kind: 'human_reconnect_account',
   actor: 'human',
@@ -1074,7 +1090,7 @@ function recoveryPayload(
         : isQuotaExhausted
           ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now: ${HUMAN_CONNECTION_GUIDANCE}`
           : isToolUnavailable
-            ? `The free tier includes Search, Scrape, and Parse. This tool needs a connected account; those keyless tools still work. To use this tool: ${HUMAN_CONNECTION_GUIDANCE}`
+            ? ACCOUNT_ONLY_TOOL_GUIDANCE
             : isKeylessAccessUnavailable
               ? `Anonymous keyless access is unavailable for this request. To continue: ${HUMAN_CONNECTION_GUIDANCE}`
               : isKeylessEligibilityUnavailable

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,7 +231,8 @@ function escapeWWWAuthenticateValue(value: string): string {
 
 function createOAuthChallengeResponse(
   error: unknown,
-  profile: ServerProfile
+  profile: ServerProfile,
+  details: Record<string, unknown> = {}
 ): Response | undefined {
   if (!isMcpOAuthEnabled()) {
     return undefined;
@@ -253,6 +254,7 @@ function createOAuthChallengeResponse(
     JSON.stringify({
       error: 'invalid_token',
       error_description: errorMessage,
+      ...details,
     }),
     {
       headers: {
@@ -264,11 +266,13 @@ function createOAuthChallengeResponse(
   );
 }
 
-function createInvalidCredentialResponse(error: InvalidFirecrawlCredentialError): Response {
+function createInvalidCredentialResponse(_error: InvalidFirecrawlCredentialError): Response {
+  const recovery = invalidApiKeyRecoveryPayload();
   return new Response(
     JSON.stringify({
       error: 'invalid_api_key',
-      error_description: error.message,
+      error_description: recovery.message,
+      ...recovery,
     }),
     {
       headers: { 'Content-Type': 'application/json' },
@@ -324,6 +328,13 @@ class InvalidFirecrawlCredentialError extends Error {
   constructor() {
     super('The supplied Firecrawl credential is invalid or revoked. Replace it and retry.');
     this.name = 'InvalidFirecrawlCredentialError';
+  }
+}
+
+class InvalidOAuthCredentialError extends Error {
+  constructor() {
+    super('Invalid OAuth access token');
+    this.name = 'InvalidOAuthCredentialError';
   }
 }
 
@@ -433,7 +444,7 @@ async function resolveCredentialFromHeaders(
   }
   if (!data.active || !data.api_key) {
     if (isFirecrawlOAuthAccessToken(token)) {
-      throw new Error('Invalid OAuth access token');
+      throw new InvalidOAuthCredentialError();
     }
     return { invalid: true };
   }
@@ -668,6 +679,15 @@ function makeAuthenticate(profile: ServerProfile) {
         emitLegacyKeyPathTelemetry(profile, request, 'rejected');
         if (error instanceof InvalidFirecrawlCredentialError) {
           throw createInvalidCredentialResponse(error);
+        }
+        if (error instanceof InvalidOAuthCredentialError) {
+          const recovery = invalidOAuthRecoveryPayload(profile);
+          const oauthChallenge = createOAuthChallengeResponse(
+            new Error(recovery.message),
+            profile,
+            recovery
+          );
+          if (oauthChallenge) throw oauthChallenge;
         }
         if (error instanceof CredentialValidationUnavailableError) {
           throw new Response(
@@ -974,24 +994,63 @@ const API_KEY_SIGNUP_URL = 'https://www.firecrawl.dev/app/api-keys';
 const HUMAN_CONNECTION_GUIDANCE =
   `A human or operator must complete the connection because this session cannot reconnect Firecrawl itself. Ask the human to choose before changing anything: (1) in the MCP client's settings, update or replace the existing Firecrawl server entry so its URL is ${MCP_OAUTH_SERVER_URL}, then complete sign-in through the client. That URL is a client configuration value, not a page to open in a browser. Do not add a second Firecrawl server or change configuration without approval; or (2) have an operator create an API key at ${API_KEY_SIGNUP_URL} and configure it in the client or secret manager outside this chat. Never ask for, accept, or put an API key in chat or in an MCP URL. After the human confirms setup, start a new client session or run and retry the original task. Connection guide: ${MCP_CONNECTION_GUIDE_URL}`;
 
+const HUMAN_RECONNECT_ACCOUNT_ACTION = {
+  kind: 'human_reconnect_account',
+  actor: 'human',
+  requires_user_consent: true,
+  existing_server_only: true,
+  server_url: MCP_OAUTH_SERVER_URL,
+  open_server_url_in_browser: false,
+  docs_url: MCP_CONNECTION_GUIDE_URL,
+} as const;
+
+const OPERATOR_CONFIGURE_API_KEY_ACTION = {
+  kind: 'operator_configure_api_key',
+  actor: 'human_or_operator',
+  requires_user_consent: true,
+  credential_delivery: 'outside_agent_chat',
+  signup_url: API_KEY_SIGNUP_URL,
+} as const;
+
 const HUMAN_CONNECTION_ACTIONS = [
-  {
-    kind: 'human_reconnect_account',
-    actor: 'human',
-    requires_user_consent: true,
-    existing_server_only: true,
-    server_url: MCP_OAUTH_SERVER_URL,
-    open_server_url_in_browser: false,
-    docs_url: MCP_CONNECTION_GUIDE_URL,
-  },
-  {
-    kind: 'operator_configure_api_key',
-    actor: 'human_or_operator',
-    requires_user_consent: true,
-    credential_delivery: 'outside_agent_chat',
-    signup_url: API_KEY_SIGNUP_URL,
-  },
+  HUMAN_RECONNECT_ACCOUNT_ACTION,
+  OPERATOR_CONFIGURE_API_KEY_ACTION,
 ] as const;
+
+function invalidApiKeyRecoveryPayload(): Record<string, unknown> & { message: string } {
+  return {
+    code: 'CREDENTIAL_INVALID',
+    auth_mode: 'api_key',
+    message:
+      'The Firecrawl API key configured for this server is invalid or revoked. Ask a human or operator to replace it in this existing server configuration or secret manager outside this chat. Never ask for, accept, or put an API key in chat or in an MCP URL. After the human confirms the change, start a new client session or run and retry the original task.',
+    docs_url: MCP_CONNECTION_GUIDE_URL,
+    next_actions: [OPERATOR_CONFIGURE_API_KEY_ACTION],
+  };
+}
+
+function invalidOAuthRecoveryPayload(
+  profile: ServerProfile
+): Record<string, unknown> & { message: string } {
+  if (profile.advertiseOAuth) {
+    return {
+      code: 'OAUTH_CONNECTION_INVALID',
+      auth_mode: 'oauth',
+      message:
+        "This Firecrawl account connection is no longer valid. Ask the human to sign in again through this MCP client's account-connection flow. Do not add a second Firecrawl server or open the MCP server URL directly in a browser. After sign-in, start a new client session or run and retry the original task.",
+      docs_url: MCP_CONNECTION_GUIDE_URL,
+      next_actions: [HUMAN_RECONNECT_ACCOUNT_ACTION, OPERATOR_CONFIGURE_API_KEY_ACTION],
+    };
+  }
+
+  return {
+    code: 'OAUTH_CONNECTION_INVALID',
+    auth_mode: 'oauth',
+    message:
+      `This Firecrawl account connection is no longer valid, and this server does not start account sign-in. Ask the human to choose before changing anything: (1) have an operator create a Firecrawl API key at ${API_KEY_SIGNUP_URL} and configure it on this existing server outside this chat; or (2) update this existing server's URL to ${MCP_OAUTH_SERVER_URL} and complete sign-in through the MCP client. That URL is a client configuration value, not a page to open in a browser. Never ask for, accept, or put an API key in chat or in an MCP URL. After the human confirms the change, start a new client session or run and retry the original task.`,
+    docs_url: MCP_CONNECTION_GUIDE_URL,
+    next_actions: [OPERATOR_CONFIGURE_API_KEY_ACTION, HUMAN_RECONNECT_ACCOUNT_ACTION],
+  };
+}
 
 function recoveryPayload(
   code: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,6 +169,20 @@ const DEFAULT_MCP_OAUTH_RESOURCE_URL = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
 const DEFAULT_MCP_SEARCH_RESOURCE_URL = 'https://mcp.firecrawl.dev/v2/mcp-search';
 const DEFAULT_MCP_SEARCH_ENDPOINT = '/v2/mcp-search';
 
+// Human-facing guidance values, co-located with the resource defaults above.
+// MCP_CONNECTION_GUIDE_URL stays a stable, neutral entry point even while the
+// docs routing evolves; do not bind recovery payloads to an auth-mode leaf
+// page. It is a human-facing guide, not an MCP endpoint.
+// MCP_OAUTH_SERVER_URL intentionally repeats the value of
+// DEFAULT_MCP_OAUTH_RESOURCE_URL without aliasing it: the resource constant is
+// protocol identity and can be overridden per deployment via
+// FIRECRAWL_MCP_RESOURCE_URL, while this one is the fixed value a human puts
+// in MCP client settings for the hosted service.
+const MCP_CONNECTION_GUIDE_URL =
+  'https://docs.firecrawl.dev/mcp-server';
+const MCP_OAUTH_SERVER_URL = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
+const API_KEY_SIGNUP_URL = 'https://www.firecrawl.dev/app/api-keys';
+
 function withoutTrailingSlash(value: string): string {
   return value.replace(/\/+$/, '');
 }
@@ -994,15 +1008,6 @@ function isLocalKeylessStartup(): boolean {
     !normalizeHeader(process.env.FIRECRAWL_API_URL)
   );
 }
-
-// Keep this stable, neutral entry point even while the docs routing evolves;
-// do not bind recovery payloads to an auth-mode leaf page. This is a
-// human-facing guide, not an MCP endpoint. The OAuth endpoint below is named
-// separately and only as the value a human puts in MCP client settings.
-const MCP_CONNECTION_GUIDE_URL =
-  'https://docs.firecrawl.dev/mcp-server';
-const MCP_OAUTH_SERVER_URL = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
-const API_KEY_SIGNUP_URL = 'https://www.firecrawl.dev/app/api-keys';
 
 // Shared security-boundary phrasing: the API key must never pass through
 // chat/MCP URLs, and any recovery only takes effect on the next session/run.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1073,7 +1073,10 @@ function invalidApiKeyRecoveryPayload(): Record<string, unknown> & { message: st
 function invalidOAuthRecoveryPayload(
   profile: ServerProfile
 ): Record<string, unknown> & { message: string } {
-  if (profile.advertiseOAuth) {
+  // The reconnect-through-this-client message is only true when OAuth is
+  // globally enabled AND this profile advertises it; otherwise fall through to
+  // the guidance for servers that do not start account sign-in.
+  if (isMcpOAuthEnabled() && profile.advertiseOAuth) {
     return connectionRecoveryPayload({
       code: 'OAUTH_CONNECTION_INVALID',
       authMode: 'oauth',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1004,8 +1004,17 @@ const MCP_CONNECTION_GUIDE_URL =
 const MCP_OAUTH_SERVER_URL = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
 const API_KEY_SIGNUP_URL = 'https://www.firecrawl.dev/app/api-keys';
 
+// Shared security-boundary phrasing: the API key must never pass through
+// chat/MCP URLs, and any recovery only takes effect on the next session/run.
+// Keep these as the single source of truth so every recovery/guidance string
+// that needs them composes from here instead of re-typing the wording.
+const NEVER_SHARE_API_KEY_SENTENCE =
+  'Never ask for, accept, or put an API key in chat or in an MCP URL.';
+const RETRY_AFTER_CONFIRM_SUFFIX =
+  'start a new client session or run and retry the original task.';
+
 const HUMAN_CONNECTION_GUIDANCE =
-  `A human or operator must complete the connection because this session cannot reconnect Firecrawl itself. Ask the human to choose before changing anything: (1) in the MCP client's settings, update or replace the existing Firecrawl server entry so its URL is ${MCP_OAUTH_SERVER_URL}, then complete sign-in through the client. That URL is a client configuration value, not a page to open in a browser. Do not add a second Firecrawl server or change configuration without approval; or (2) have an operator create an API key at ${API_KEY_SIGNUP_URL} and configure it in the client or secret manager outside this chat. Never ask for, accept, or put an API key in chat or in an MCP URL. After the human confirms setup, start a new client session or run and retry the original task. Connection guide: ${MCP_CONNECTION_GUIDE_URL}`;
+  `A human or operator must complete the connection because this session cannot reconnect Firecrawl itself. Ask the human to choose before changing anything: (1) in the MCP client's settings, update or replace the existing Firecrawl server entry so its URL is ${MCP_OAUTH_SERVER_URL}, then complete sign-in through the client. That URL is a client configuration value, not a page to open in a browser. Do not add a second Firecrawl server or change configuration without approval; or (2) have an operator create an API key at ${API_KEY_SIGNUP_URL} and configure it in the client or secret manager outside this chat. ${NEVER_SHARE_API_KEY_SENTENCE} After the human confirms setup, ${RETRY_AFTER_CONFIRM_SUFFIX} Connection guide: ${MCP_CONNECTION_GUIDE_URL}`;
 
 const ACCOUNT_ONLY_TOOL_GUIDANCE =
   `This tool needs a connected Firecrawl account. Search, Scrape, and Parse remain available, so continue with those if they can complete the task. Only if this task specifically requires this tool, tell the user that a human must update the existing Firecrawl connection using ${MCP_CONNECTION_GUIDE_URL}. Never ask for or accept an API key in chat. After setup, start a new client session and retry.`;
@@ -1033,39 +1042,54 @@ const HUMAN_CONNECTION_ACTIONS = [
   OPERATOR_CONFIGURE_API_KEY_ACTION,
 ] as const;
 
-function invalidApiKeyRecoveryPayload(): Record<string, unknown> & { message: string } {
+// Shared shape for the two "existing connection is invalid" recovery
+// payloads below: same code/auth_mode/docs_url/next_actions fields, only the
+// message and next_actions ordering differ per credential type.
+function connectionRecoveryPayload(params: {
+  code: string;
+  authMode: string;
+  message: string;
+  nextActions: readonly unknown[];
+}): Record<string, unknown> & { message: string } {
   return {
-    code: 'CREDENTIAL_INVALID',
-    auth_mode: 'api_key',
-    message:
-      'The Firecrawl API key configured for this server is invalid or revoked. Ask a human or operator to replace it in this existing server configuration or secret manager outside this chat. Never ask for, accept, or put an API key in chat or in an MCP URL. After the human confirms the change, start a new client session or run and retry the original task.',
+    code: params.code,
+    auth_mode: params.authMode,
+    message: params.message,
     docs_url: MCP_CONNECTION_GUIDE_URL,
-    next_actions: [OPERATOR_CONFIGURE_API_KEY_ACTION],
+    next_actions: params.nextActions,
   };
+}
+
+function invalidApiKeyRecoveryPayload(): Record<string, unknown> & { message: string } {
+  return connectionRecoveryPayload({
+    code: 'CREDENTIAL_INVALID',
+    authMode: 'api_key',
+    message:
+      `The Firecrawl API key configured for this server is invalid or revoked. Ask a human or operator to replace it in this existing server configuration or secret manager outside this chat. ${NEVER_SHARE_API_KEY_SENTENCE} After the human confirms the change, ${RETRY_AFTER_CONFIRM_SUFFIX}`,
+    nextActions: [OPERATOR_CONFIGURE_API_KEY_ACTION],
+  });
 }
 
 function invalidOAuthRecoveryPayload(
   profile: ServerProfile
 ): Record<string, unknown> & { message: string } {
   if (profile.advertiseOAuth) {
-    return {
+    return connectionRecoveryPayload({
       code: 'OAUTH_CONNECTION_INVALID',
-      auth_mode: 'oauth',
+      authMode: 'oauth',
       message:
-        "This Firecrawl account connection is no longer valid. Ask the human to sign in again through this MCP client's account-connection flow. Do not add a second Firecrawl server or open the MCP server URL directly in a browser. After sign-in, start a new client session or run and retry the original task.",
-      docs_url: MCP_CONNECTION_GUIDE_URL,
-      next_actions: [HUMAN_RECONNECT_ACCOUNT_ACTION, OPERATOR_CONFIGURE_API_KEY_ACTION],
-    };
+        `This Firecrawl account connection is no longer valid. Ask the human to sign in again through this MCP client's account-connection flow. Do not add a second Firecrawl server or open the MCP server URL directly in a browser. After sign-in, ${RETRY_AFTER_CONFIRM_SUFFIX}`,
+      nextActions: [HUMAN_RECONNECT_ACCOUNT_ACTION, OPERATOR_CONFIGURE_API_KEY_ACTION],
+    });
   }
 
-  return {
+  return connectionRecoveryPayload({
     code: 'OAUTH_CONNECTION_INVALID',
-    auth_mode: 'oauth',
+    authMode: 'oauth',
     message:
-      `This Firecrawl account connection is no longer valid, and this server does not start account sign-in. Ask the human to choose before changing anything: (1) have an operator create a Firecrawl API key at ${API_KEY_SIGNUP_URL} and configure it on this existing server outside this chat; or (2) update this existing server's URL to ${MCP_OAUTH_SERVER_URL} and complete sign-in through the MCP client. That URL is a client configuration value, not a page to open in a browser. Never ask for, accept, or put an API key in chat or in an MCP URL. After the human confirms the change, start a new client session or run and retry the original task.`,
-    docs_url: MCP_CONNECTION_GUIDE_URL,
-    next_actions: [OPERATOR_CONFIGURE_API_KEY_ACTION, HUMAN_RECONNECT_ACCOUNT_ACTION],
-  };
+      `This Firecrawl account connection is no longer valid, and this server does not start account sign-in. Ask the human to choose before changing anything: (1) have an operator create a Firecrawl API key at ${API_KEY_SIGNUP_URL} and configure it on this existing server outside this chat; or (2) update this existing server's URL to ${MCP_OAUTH_SERVER_URL} and complete sign-in through the MCP client. That URL is a client configuration value, not a page to open in a browser. ${NEVER_SHARE_API_KEY_SENTENCE} After the human confirms the change, ${RETRY_AFTER_CONFIRM_SUFFIX}`,
+    nextActions: [OPERATOR_CONFIGURE_API_KEY_ACTION, HUMAN_RECONNECT_ACCOUNT_ACTION],
+  });
 }
 
 function recoveryPayload(

--- a/src/index.ts
+++ b/src/index.ts
@@ -962,6 +962,35 @@ function isLocalKeylessStartup(): boolean {
   );
 }
 
+// Keep this stable, neutral entry point even while the docs routing evolves;
+// do not bind recovery payloads to an auth-mode leaf page. This is a
+// human-facing guide, not an MCP endpoint. The OAuth endpoint below is named
+// separately and only as the value a human puts in MCP client settings.
+const MCP_CONNECTION_GUIDE_URL =
+  'https://docs.firecrawl.dev/mcp-server';
+const MCP_OAUTH_SERVER_URL = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
+
+const HUMAN_CONNECTION_GUIDANCE =
+  `This session cannot reconnect Firecrawl itself. Ask the human to choose before changing anything: (1) in the MCP client's settings, update or replace the existing Firecrawl server entry so its URL is ${MCP_OAUTH_SERVER_URL}, then complete sign-in through the client. That URL is a client configuration value, not a page to open in a browser. Do not add a second Firecrawl server or change configuration without approval; or (2) have an operator configure an API key in the client or secret manager outside this chat. Never ask for, accept, or put an API key in chat or in an MCP URL. After the human confirms setup, start a new client session or run and retry the original task. Connection guide: ${MCP_CONNECTION_GUIDE_URL}`;
+
+const HUMAN_CONNECTION_ACTIONS = [
+  {
+    kind: 'human_reconnect_account',
+    actor: 'human',
+    requires_user_consent: true,
+    existing_server_only: true,
+    server_url: MCP_OAUTH_SERVER_URL,
+    open_server_url_in_browser: false,
+    docs_url: MCP_CONNECTION_GUIDE_URL,
+  },
+  {
+    kind: 'operator_configure_api_key',
+    actor: 'human_or_operator',
+    requires_user_consent: true,
+    credential_delivery: 'outside_agent_chat',
+  },
+] as const;
+
 function recoveryPayload(
   code: string,
   requestId: string = randomUUID(),
@@ -974,40 +1003,35 @@ function recoveryPayload(
   const isKeylessAccessUnavailable = code === 'KEYLESS_ACCESS_NOT_AVAILABLE';
   const isKeylessEligibilityUnavailable =
     code === 'KEYLESS_ELIGIBILITY_UNAVAILABLE';
-  const oauthUrl = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
   return {
     code,
     request_id: requestId,
     auth_mode: code === 'CREDENTIAL_INVALID' ? 'credential_error' : 'keyless',
     message:
       code === 'CREDENTIAL_INVALID'
-        ? `The supplied Firecrawl credential is invalid or revoked. Reconnect the account via OAuth (https://mcp.firecrawl.dev/v2/mcp-oauth) or create a new API key at https://www.firecrawl.dev/signin and send it as Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
+        ? `The supplied Firecrawl credential is invalid or revoked. ${HUMAN_CONNECTION_GUIDANCE}`
         : isQuotaExhausted
-          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now, connect a Firecrawl account via OAuth (https://mcp.firecrawl.dev/v2/mcp-oauth) or create a free API key at https://www.firecrawl.dev/signin and send it as Authorization: Bearer <FIRECRAWL_API_KEY>.`
+          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now, ${HUMAN_CONNECTION_GUIDANCE}`
           : isToolUnavailable
             ? 'The free tier includes Search, Scrape, and Parse. This tool needs a connected account; Search, Scrape, and Parse still work, so no action is required.'
             : isKeylessAccessUnavailable
-              ? `Anonymous keyless access is unavailable for this request. To continue, connect a Firecrawl account via OAuth (https://mcp.firecrawl.dev/v2/mcp-oauth) or create a free API key at https://www.firecrawl.dev/signin and send it as Authorization: Bearer <FIRECRAWL_API_KEY>.`
+              ? `Anonymous keyless access is unavailable for this request. To continue, ${HUMAN_CONNECTION_GUIDANCE}`
               : isKeylessEligibilityUnavailable
                 ? 'The anonymous keyless eligibility check is temporarily unavailable. Retry shortly.'
-              : `This tool requires a Firecrawl account or API key. Connect an account via OAuth (https://mcp.firecrawl.dev/v2/mcp-oauth) or create a free API key at https://www.firecrawl.dev/signin and send it as Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`,
+              : `This tool requires a Firecrawl account or API key. ${HUMAN_CONNECTION_GUIDANCE}`,
     ...(isKeylessAccessUnavailable
       ? {}
       : { available_tools: [...KEYLESS_TOOL_NAMES] }),
-    docs_url: 'https://docs.firecrawl.dev/mcp-server',
+    docs_url: MCP_CONNECTION_GUIDE_URL,
     ...(retryAfterSeconds ? { retry_after_seconds: retryAfterSeconds } : {}),
     next_actions: isKeylessEligibilityUnavailable
       ? [{ kind: 'retry_later', after_seconds: 30 }]
       : isQuotaExhausted || isKeylessAccessUnavailable
-      ? [
-          { kind: 'connect_oauth', url: oauthUrl, client_commands: [{ client: 'claude-code', command: 'claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth' }] },
-          { kind: 'configure_api_key', header: 'Authorization: Bearer <FIRECRAWL_API_KEY>' },
-        ]
+      ? HUMAN_CONNECTION_ACTIONS
       : isToolUnavailable
         ? [{ kind: 'continue_keyless', tools: [...KEYLESS_TOOL_NAMES] }]
         : [
-            { kind: 'connect_oauth', url: oauthUrl },
-            { kind: 'configure_api_key', header: 'Authorization: Bearer <FIRECRAWL_API_KEY>' },
+            ...HUMAN_CONNECTION_ACTIONS,
           ],
   };
 }

--- a/src/www-authenticate.ts
+++ b/src/www-authenticate.ts
@@ -1,0 +1,3 @@
+export function escapeWWWAuthenticateValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -496,11 +496,12 @@ test('search surface rejects an invalid raw API credential during tools/list', a
   });
   assert.equal(res.status, 401);
   assert.equal(res.headers.has('www-authenticate'), false);
-  assert.deepEqual(await res.json(), {
-    error: 'invalid_api_key',
-    error_description:
-      'The supplied Firecrawl credential is invalid or revoked. Replace it and retry.',
-  });
+  const body = await res.json();
+  assert.equal(body.error, 'invalid_api_key');
+  assert.equal(body.code, 'CREDENTIAL_INVALID');
+  assert.match(body.error_description, /outside this chat/);
+  assert.equal(body.next_actions[0].kind, 'operator_configure_api_key');
+  assert.equal(body.next_actions[0].requires_user_consent, true);
 });
 
 test('search surface rejects an invalid raw API credential before a tool call', async (t) => {
@@ -521,11 +522,12 @@ test('search surface rejects an invalid raw API credential before a tool call', 
   });
   assert.equal(res.status, 401);
   assert.equal(res.headers.has('www-authenticate'), false);
-  assert.deepEqual(await res.json(), {
-    error: 'invalid_api_key',
-    error_description:
-      'The supplied Firecrawl credential is invalid or revoked. Replace it and retry.',
-  });
+  const body = await res.json();
+  assert.equal(body.error, 'invalid_api_key');
+  assert.equal(body.code, 'CREDENTIAL_INVALID');
+  assert.match(body.error_description, /outside this chat/);
+  assert.equal(body.next_actions[0].kind, 'operator_configure_api_key');
+  assert.equal(body.next_actions[0].requires_user_consent, true);
   assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
 });
 

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1126,8 +1126,39 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
     const result = parseSseJson(await response.text()).result;
     assert.equal(result.isError, true, label);
     assert.equal(result.structuredContent.code, expectedCode, label);
-    assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth', label);
-    if (label === 'with-reason') assert.equal(result.structuredContent.retry_after_seconds, 42);
+    assert.deepEqual(result.structuredContent.next_actions, [
+      {
+        kind: 'human_reconnect_account',
+        actor: 'human',
+        requires_user_consent: true,
+        existing_server_only: true,
+        server_url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+        open_server_url_in_browser: false,
+        docs_url:
+          'https://docs.firecrawl.dev/mcp-server',
+      },
+      {
+        kind: 'operator_configure_api_key',
+        actor: 'human_or_operator',
+        requires_user_consent: true,
+        credential_delivery: 'outside_agent_chat',
+      },
+    ], label);
+    assert.match(result.content[0].text, /Ask the human to choose/, label);
+    assert.match(result.content[0].text, /update or replace the existing Firecrawl server entry/, label);
+    assert.match(result.content[0].text, /client configuration value, not a page to open/, label);
+    assert.match(result.content[0].text, /outside this chat/, label);
+    assert.match(result.content[0].text, /new client session or run/, label);
+    // The OAuth endpoint must be present and explicitly framed as configuration.
+    // This is the inverse of the earlier no-endpoint recovery contract.
+    assert.match(result.content[0].text, /mcp\.firecrawl\.dev\/v2\/mcp-oauth/, label);
+    assert.match(result.content[0].text, /docs\.firecrawl\.dev\/mcp-server(?:\s|$)/, label);
+    assert.doesNotMatch(result.content[0].text, /Authorization: Bearer/, label);
+    assert.doesNotMatch(result.content[0].text, /claude mcp add/, label);
+    if (label === 'with-reason') {
+      assert.equal(result.structuredContent.retry_after_seconds, 42);
+      assert.match(result.content[0].text, /about 42 seconds/);
+    }
     await cleanup();
   }
 });
@@ -1290,7 +1321,8 @@ test('HTTP cloud keyless rejects multi-hop or malformed forwarded IP identity', 
     const result = parseSseJson(await response.text()).result;
     assert.equal(result.isError, true, xff);
     assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE', xff);
-    assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth', xff);
+    assert.equal(result.structuredContent.next_actions[0].kind, 'human_reconnect_account', xff);
+    assert.equal(result.structuredContent.next_actions[0].actor, 'human', xff);
     assert.equal(result.structuredContent.available_tools, undefined, xff);
   }
   assert.equal(backend.requests.length, 0, JSON.stringify(backend.requests));
@@ -1443,7 +1475,8 @@ test('HTTP cloud transport returns recovery when keyless identity has no client 
   const result = parseSseJson(await toolCall.text()).result;
   assert.equal(result.isError, true);
   assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE');
-  assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth');
+  assert.equal(result.structuredContent.next_actions[0].kind, 'human_reconnect_account');
+  assert.equal(result.structuredContent.next_actions[0].actor, 'human');
   assert.equal(result.structuredContent.available_tools, undefined);
   assertServerGeneratedRequestId(result.structuredContent, [
     'client-json-rpc-id',

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1082,12 +1082,35 @@ test('HTTP cloud keyless continues with free-tier tools when an account-only too
       kind: 'continue_keyless',
       tools: ['firecrawl_scrape', 'firecrawl_search', 'firecrawl_parse'],
     },
+    {
+      kind: 'human_reconnect_account',
+      actor: 'human',
+      requires_user_consent: true,
+      existing_server_only: true,
+      server_url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+      open_server_url_in_browser: false,
+      docs_url: 'https://docs.firecrawl.dev/mcp-server',
+    },
+    {
+      kind: 'operator_configure_api_key',
+      actor: 'human_or_operator',
+      requires_user_consent: true,
+      credential_delivery: 'outside_agent_chat',
+      signup_url: 'https://www.firecrawl.dev/app/api-keys',
+    },
   ]);
   assert.deepEqual(result.structuredContent.available_tools, [
     'firecrawl_scrape',
     'firecrawl_search',
     'firecrawl_parse',
   ]);
+  assert.match(result.content[0].text, /those keyless tools still work/);
+  assert.match(result.content[0].text, /To use this tool:/);
+  assert.match(result.content[0].text, /Ask the human to choose/);
+  assert.match(result.content[0].text, /outside this chat/);
+  assert.match(result.content[0].text, /new client session or run/);
+  assert.doesNotMatch(result.content[0].text, /no action is required/);
+  assert.doesNotMatch(result.content[0].text, /Authorization: Bearer/);
   assert.equal(backend.requests.some((r) => r.url === '/v2/crawl'), false);
 });
 
@@ -1142,6 +1165,7 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
         actor: 'human_or_operator',
         requires_user_consent: true,
         credential_delivery: 'outside_agent_chat',
+        signup_url: 'https://www.firecrawl.dev/app/api-keys',
       },
     ], label);
     assert.match(result.content[0].text, /Ask the human to choose/, label);

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -951,6 +951,48 @@ test('HTTP cloud keyless transport rejects inactive OAuth without advertising lo
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
 
+test('HTTP transport returns invalid OAuth recovery without an OAuth challenge when OAuth is disabled', async (t) => {
+  const backend = await startFakeFirecrawlBackend();
+  t.after(() => backend.close());
+
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'false',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'introspect-secret',
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    HOST: '127.0.0.1',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+
+  await waitForHealth(port, child);
+
+  const response = await httpToolCall(port, {
+    id: 'invalid-oauth-without-challenge',
+    headers: { authorization: 'Bearer fco_invalid_token' },
+    params: {
+      arguments: { limit: 1, query: 'example domain' },
+      name: 'firecrawl_search',
+    },
+  });
+
+  assert.equal(response.status, 401);
+  assert.equal(response.headers.get('www-authenticate'), null);
+  const body = await response.json();
+  assert.equal(body.error, 'invalid_token');
+  assert.equal(body.code, 'OAUTH_CONNECTION_INVALID');
+  assert.equal(body.auth_mode, 'oauth');
+  assert.match(body.error_description, /account connection is no longer valid/);
+  assert.match(
+    body.error_description,
+    /Never ask for, accept, or put an API key in chat/
+  );
+  assert.equal(backend.requests.some((request) => request.url === '/v2/search'), false);
+});
+
 test('HTTP cloud transport accepts the x-firecrawl-api-key header', async (t) => {
   const backend = await startFakeFirecrawlBackend();
   t.after(() => backend.close());
@@ -1127,11 +1169,13 @@ test('HTTP cloud keyless continues with free-tier tools when an account-only too
     'firecrawl_search',
     'firecrawl_parse',
   ]);
-  assert.match(result.content[0].text, /those keyless tools still work/);
-  assert.match(result.content[0].text, /To use this tool:/);
-  assert.match(result.content[0].text, /Ask the human to choose/);
-  assert.match(result.content[0].text, /outside this chat/);
-  assert.match(result.content[0].text, /new client session or run/);
+  assert.match(result.content[0].text, /Search, Scrape, and Parse remain available/);
+  assert.match(result.content[0].text, /continue with those if they can complete the task/);
+  assert.match(result.content[0].text, /Only if this task specifically requires this tool/);
+  assert.match(result.content[0].text, /https:\/\/docs\.firecrawl\.dev\/mcp-server/);
+  assert.match(result.content[0].text, /Never ask for or accept an API key in chat/);
+  assert.match(result.content[0].text, /new client session and retry/);
+  assert.doesNotMatch(result.content[0].text, /mcp\.firecrawl\.dev\/v2\/mcp-oauth/);
   assert.doesNotMatch(result.content[0].text, /no action is required/);
   assert.doesNotMatch(result.content[0].text, /Authorization: Bearer/);
   assert.equal(backend.requests.some((r) => r.url === '/v2/crawl'), false);

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -923,6 +923,29 @@ test('HTTP cloud keyless transport rejects inactive OAuth without advertising lo
   assert.match(wwwAuthenticate, /error="invalid_token"/);
   const body = await toolCall.json();
   assert.equal(body.error, 'invalid_token');
+  assert.equal(body.code, 'OAUTH_CONNECTION_INVALID');
+  assert.equal(body.auth_mode, 'oauth');
+  assert.match(body.error_description, /server does not start account sign-in/);
+  assert.match(body.error_description, /client configuration value, not a page to open/);
+  assert.doesNotMatch(body.error_description, /Authorization: Bearer/);
+  assert.deepEqual(body.next_actions, [
+    {
+      kind: 'operator_configure_api_key',
+      actor: 'human_or_operator',
+      requires_user_consent: true,
+      credential_delivery: 'outside_agent_chat',
+      signup_url: 'https://www.firecrawl.dev/app/api-keys',
+    },
+    {
+      kind: 'human_reconnect_account',
+      actor: 'human',
+      requires_user_consent: true,
+      existing_server_only: true,
+      server_url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+      open_server_url_in_browser: false,
+      docs_url: 'https://docs.firecrawl.dev/mcp-server',
+    },
+  ]);
   // The failed introspection must NOT leak downstream as an API call.
   assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
   assert.equal(stderr.includes('TypeError'), false, stderr);
@@ -1597,6 +1620,49 @@ test('account endpoint challenges anonymous clients and accepts API keys', async
   assert.ok(names.length > 3);
 });
 
+test('account endpoint keeps OAuth discovery and gives safe re-auth guidance for inactive OAuth', async (t) => {
+  const backend = await startFakeFirecrawlBackend();
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp-oauth',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_MCP_RESOURCE_URL: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const response = await httpToolCall(port, {
+    endpoint: '/v2/mcp-oauth',
+    headers: { authorization: 'Bearer fco_invalid_account_token' },
+    id: 'invalid-account-token',
+    params: {
+      arguments: { limit: 1, query: 'example domain' },
+      name: 'firecrawl_search',
+    },
+  });
+
+  assert.equal(response.status, 401);
+  const wwwAuthenticate = response.headers.get('www-authenticate') ?? '';
+  assert.match(wwwAuthenticate, /resource_metadata=/);
+  assert.match(wwwAuthenticate, /oauth-protected-resource\/v2\/mcp-oauth/);
+  const body = await response.json();
+  assert.equal(body.error, 'invalid_token');
+  assert.equal(body.code, 'OAUTH_CONNECTION_INVALID');
+  assert.equal(body.auth_mode, 'oauth');
+  assert.match(body.error_description, /sign in again through this MCP client's account-connection flow/);
+  assert.match(body.error_description, /start a new client session or run/);
+  assert.equal(body.next_actions[0].kind, 'human_reconnect_account');
+  assert.equal(body.next_actions[0].requires_user_consent, true);
+  assert.equal(body.next_actions[1].kind, 'operator_configure_api_key');
+  assert.equal(backend.requests.some((request) => request.url === '/v2/search'), false);
+});
+
 test('account readiness requires the managed OAuth delegation secret', async (t) => {
   const backend = await startFakeFirecrawlBackend();
   t.after(() => backend.close());
@@ -1971,6 +2037,24 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
   });
   assert.equal(replay.status, 401);
 
+  const invalidApiKeyRecovery = {
+    error: 'invalid_api_key',
+    error_description:
+      'The Firecrawl API key configured for this server is invalid or revoked. Ask a human or operator to replace it in this existing server configuration or secret manager outside this chat. Never ask for, accept, or put an API key in chat or in an MCP URL. After the human confirms the change, start a new client session or run and retry the original task.',
+    code: 'CREDENTIAL_INVALID',
+    auth_mode: 'api_key',
+    message:
+      'The Firecrawl API key configured for this server is invalid or revoked. Ask a human or operator to replace it in this existing server configuration or secret manager outside this chat. Never ask for, accept, or put an API key in chat or in an MCP URL. After the human confirms the change, start a new client session or run and retry the original task.',
+    docs_url: 'https://docs.firecrawl.dev/mcp-server',
+    next_actions: [{
+      kind: 'operator_configure_api_key',
+      actor: 'human_or_operator',
+      requires_user_consent: true,
+      credential_delivery: 'outside_agent_chat',
+      signup_url: 'https://www.firecrawl.dev/app/api-keys',
+    }],
+  };
+
   const invalidList = await fetch(`http://127.0.0.1:${port}/v2/mcp`, {
     body: JSON.stringify({ id: 2, jsonrpc: '2.0', method: 'tools/list', params: {} }),
     headers: {
@@ -1982,11 +2066,7 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
   });
   assert.equal(invalidList.status, 401);
   assert.equal(invalidList.headers.has('www-authenticate'), false);
-  assert.deepEqual(await invalidList.json(), {
-    error: 'invalid_api_key',
-    error_description:
-      'The supplied Firecrawl credential is invalid or revoked. Replace it and retry.',
-  });
+  assert.deepEqual(await invalidList.json(), invalidApiKeyRecovery);
 
   const invalidCall = await httpToolCall(port, {
     headers: {
@@ -1998,11 +2078,7 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
   });
   assert.equal(invalidCall.status, 401);
   assert.equal(invalidCall.headers.has('www-authenticate'), false);
-  assert.deepEqual(await invalidCall.json(), {
-    error: 'invalid_api_key',
-    error_description:
-      'The supplied Firecrawl credential is invalid or revoked. Replace it and retry.',
-  });
+  assert.deepEqual(await invalidCall.json(), invalidApiKeyRecovery);
 
   const invalidLegacyPath = await fetch(`http://127.0.0.1:${port}/v2/mcp`, {
     body: JSON.stringify({ id: 4, jsonrpc: '2.0', method: 'tools/list', params: {} }),
@@ -2016,11 +2092,7 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
   });
   assert.equal(invalidLegacyPath.status, 401);
   assert.equal(invalidLegacyPath.headers.has('www-authenticate'), false);
-  assert.deepEqual(await invalidLegacyPath.json(), {
-    error: 'invalid_api_key',
-    error_description:
-      'The supplied Firecrawl credential is invalid or revoked. Replace it and retry.',
-  });
+  assert.deepEqual(await invalidLegacyPath.json(), invalidApiKeyRecovery);
   await delay(25);
   const rejectedTelemetry = stdout
     .split(/\r?\n/)

--- a/tests/www-authenticate.test.mjs
+++ b/tests/www-authenticate.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { escapeWWWAuthenticateValue } from '../dist/www-authenticate.js';
+
+test('WWW-Authenticate values escape double quotes', () => {
+  assert.equal(escapeWWWAuthenticateValue('say "hi"'), 'say \\"hi\\"');
+});
+
+test('WWW-Authenticate values escape backslashes', () => {
+  assert.equal(escapeWWWAuthenticateValue('c:\\tmp'), 'c:\\\\tmp');
+});
+
+test('WWW-Authenticate values preserve ordinary text', () => {
+  assert.equal(
+    escapeWWWAuthenticateValue('Invalid OAuth access token'),
+    'Invalid OAuth access token'
+  );
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/www-authenticate.ts'],
   format: ['esm'],
   platform: 'node',
   target: 'node22',


### PR DESCRIPTION
## Why

Keyless recovery errors are read by an agent, but connection changes and credentials belong to a human or operator.

The old recovery text could make agents stop when Search, Scrape, or Parse could still finish the task. The longer replacement guidance fixed the safety problem, but it was too heavy for a simple account-only tool miss and caused agents to repeat the raw OAuth MCP endpoint.

## What changed

- Makes account-only tool recovery fallback-first: continue with Search, Scrape, or Parse when they can complete the task
- Escalates to human setup only when the requested task truly needs the unavailable tool
- Links account-only recovery to the neutral MCP setup guide instead of putting the OAuth MCP endpoint in model-visible prose
- Keeps `continue_keyless`, `human_reconnect_account`, and `operator_configure_api_key` as structured actions
- Keeps full human/operator guidance for quota exhaustion and invalid credentials
- Keeps API keys outside agent chat and MCP URLs
- Requires a new client session or run after a connection change
- Returns structured invalid-OAuth recovery even when OAuth challenges are disabled
- Adds direct tests for `WWW-Authenticate` escaping
- Corrects the README keyless tool list and bumps the package to `3.23.7`

## Agent behavior experiment

Ran 52 valid neutral Claude Code and Codex CLI trials with a real local MCP fixture:

- 36 primary runs with Claude Opus and `gpt-5.6-sol`
- 16 lower-capability runs with Claude Haiku and `gpt-5.6-terra`
- A fallback-friendly task with five known pricing URLs
- A Crawl-required whole-site discovery task
- No prompt instruction to block, avoid fallbacks, or avoid configuration changes

Results:

- All fallback-friendly runs completed with keyless Scrape or Parse
- The final short copy gave a safe human recovery path in all 10 Crawl-required trials
- The final short copy exposed the raw OAuth MCP endpoint in 0 of 10 Crawl-required trials
- No valid run tried to change MCP configuration
- No valid run asked for a secret in chat
- No valid run falsely claimed whole-site discovery was complete
- Real Codex and Claude configuration files remained unchanged

The experiment measures how agents react after receiving the tool error. It does not measure natural first-tool selection. Managed Claude.ai and ChatGPT connectors were not testable from the local harness.

## Validation

- `FIRECRAWL_MCP_SEARCH_PORT=39241 npm test` (71 passing)
- `npx tsc --noEmit`
- `npm run lint`
- `npm pack --dry-run`
- `git diff --check`
- Independent code review and verification found no blocking issues

## Docs release order

The account-only message links to the neutral setup and recovery guide in https://github.com/firecrawl/firecrawl-docs/pull/1234. That docs PR pins `firecrawl-mcp` 3.23.7, so it should merge immediately after this version is published.

## Client boundary

Claude Code and Codex expose a startup 401 in client diagnostics, but do not currently pass it verbatim into the model context when MCP initialization fails. The HTTP recovery improves the human and diagnostic path. Connected tool-level failures remain the reliable agent-visible recovery path.

## Review focus

- Fallback-first behavior for account-only tools
- Human/operator ownership of configuration and credentials
- Structured recovery when OAuth challenges are disabled
- The neutral docs handoff and release order

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788776809&installation_model_id=11126&pr_number=363&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F363&signature=5f3ce954aa985b1ac9d118887a8758887845a449b0571099ce3954b6b7e6b612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
