### PR TITLE
fix(mcp): stop keyless setup from triggering OAuth

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,8 @@ type ServerProfile = {
   primary?: boolean;
   /** Accept tokens minted for the legacy /v2/mcp resource during migration. */
   acceptLegacyAudience?: boolean;
+  /** Publish OAuth discovery metadata for clients configuring this surface. */
+  advertiseOAuth: boolean;
 };
 
 /** Registers a tool onto an instance; a subset of the FastMCP surface. */
@@ -238,7 +240,11 @@ function createOAuthChallengeResponse(
   const errorMessage =
     error instanceof Error ? error.message : String(error || 'Unauthorized');
   const wwwAuthenticate = [
-    `resource_metadata="${escapeWWWAuthenticateValue(getOAuthProtectedResourceMetadataUrl(profile))}"`,
+    ...(profile.advertiseOAuth
+      ? [
+          `resource_metadata="${escapeWWWAuthenticateValue(getOAuthProtectedResourceMetadataUrl(profile))}"`,
+        ]
+      : []),
     'error="invalid_token"',
     `error_description="${escapeWWWAuthenticateValue(errorMessage)}"`,
   ].join(', ');
@@ -856,6 +862,7 @@ function makeFullProfile(): ServerProfile {
     acceptApiKeys: true,
     acceptLegacyAudience:
       account && process.env.MCP_OAUTH_ACCEPT_LEGACY_V2_MCP_AUD !== 'false',
+    advertiseOAuth: account,
     primary: true,
   };
 }
@@ -887,6 +894,7 @@ function makeSearchProfile({ primary = false }: { primary?: boolean } = {}): Ser
     // deployment explicitly enables the same profile flag used by primary.
     acceptApiKeys: !oauthOnly,
     requireManagedOAuth: oauthOnly,
+    advertiseOAuth: true,
     primary,
   };
 }
@@ -905,7 +913,7 @@ function createServer(profile: ServerProfile): FastMCP<SessionData> {
     logger: new ConsoleLogger(),
     roots: { enabled: false },
     oauth: {
-      enabled: isMcpOAuthEnabled(),
+      enabled: isMcpOAuthEnabled() && profile.advertiseOAuth,
       protectedResource: {
         authorizationServers: [getOAuthIssuer()],
         bearerMethodsSupported: ['header'],

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -618,7 +618,7 @@ test('search surface accepts a token minted for its own resource', async (t) => 
 });
 
 test('full surface still exposes its complete tool set alongside the search surface', async (t) => {
-  const { fullPort, issuerUrl } = await startHostedServer(t);
+  const { fullPort } = await startHostedServer(t);
 
   // Full surface is reachable on its own port with all tools intact.
   const names = await listTools(fullPort, '/v2/mcp', { 'x-api-key': 'fc-test' });
@@ -628,18 +628,12 @@ test('full surface still exposes its complete tool set alongside the search surf
   assert.ok(names.includes('firecrawl_parse'));
   assert.ok(names.length > SEARCH_TOOLS.length);
 
-  // Its protected-resource metadata stays origin-level and unchanged.
+  // The anonymous full surface accepts credentials but does not advertise
+  // OAuth, so clients do not start login while configuring keyless MCP.
   const prm = await fetch(
     `http://127.0.0.1:${fullPort}/.well-known/oauth-protected-resource`
   );
-  assert.equal(prm.status, 200);
-  assert.deepEqual(await prm.json(), {
-    authorization_servers: [issuerUrl],
-    bearer_methods_supported: ['header'],
-    resource: 'https://mcp.firecrawl.dev/v2/mcp',
-    resource_name: 'Firecrawl MCP',
-    scopes_supported: ['firecrawl:global'],
-  });
+  assert.equal(prm.status, 404);
 });
 
 test('primary search profile is OAuth-only, six-tool frozen, and ready without keyless configuration', async (t) => {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -328,7 +328,7 @@ async function httpToolCall(port, { endpoint = '/v2/mcp', id, headers, params })
   });
 }
 
-test('HTTP cloud transport preserves Firecrawl OAuth and well-known routes', async (t) => {
+test('HTTP cloud keyless transport preserves app challenge without advertising OAuth', async (t) => {
   const backend = await startFakeFirecrawlBackend();
   t.after(() => backend.close());
   const port = await getFreePort();
@@ -360,14 +360,7 @@ test('HTTP cloud transport preserves Firecrawl OAuth and well-known routes', asy
   const prm = await fetch(
     `http://127.0.0.1:${port}/.well-known/oauth-protected-resource`
   );
-  assert.equal(prm.status, 200);
-  assert.deepEqual(await prm.json(), {
-    authorization_servers: [backend.url],
-    bearer_methods_supported: ['header'],
-    resource: 'https://mcp.firecrawl.dev/v2/mcp',
-    resource_name: 'Firecrawl MCP',
-    scopes_supported: ['firecrawl:global'],
-  });
+  assert.equal(prm.status, 404);
 
   const unauthenticated = await fetch(`http://127.0.0.1:${port}/v2/mcp`, {
     body: JSON.stringify({
@@ -895,7 +888,7 @@ test('HTTP cloud transport swaps an fco_ OAuth token for its introspected API ke
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
 
-test('HTTP cloud transport rejects an inactive fco_ token with an OAuth challenge', async (t) => {
+test('HTTP cloud keyless transport rejects inactive OAuth without advertising login', async (t) => {
   const backend = await startFakeFirecrawlBackend();
   t.after(() => backend.close());
 
@@ -926,10 +919,7 @@ test('HTTP cloud transport rejects an inactive fco_ token with an OAuth challeng
   assert.equal(toolCall.status, 401);
   const wwwAuthenticate = toolCall.headers.get('www-authenticate') ?? '';
   assert.match(wwwAuthenticate, /^Bearer /);
-  assert.match(
-    wwwAuthenticate,
-    /resource_metadata="https:\/\/mcp\.firecrawl\.dev\/\.well-known\/oauth-protected-resource"/
-  );
+  assert.equal(wwwAuthenticate.includes('resource_metadata='), false);
   assert.match(wwwAuthenticate, /error="invalid_token"/);
   const body = await toolCall.json();
   assert.equal(body.error, 'invalid_token');


### PR DESCRIPTION
## Why

`/v2/mcp` supports anonymous keyless sessions, but the hosted server also publishes OAuth protected-resource metadata for that endpoint.

Codex 0.146.0 discovers that metadata during `codex mcp add` and immediately starts browser authentication. This happens before the user makes a tool call, so the documented keyless command behaves like an OAuth command.

## Root cause

FastMCP OAuth discovery was enabled for every hosted server profile:

```ts
oauth: {
  enabled: isMcpOAuthEnabled(),
}
```

That couples two separate behaviors:

1. accepting valid credentials on a request;
2. advertising OAuth during client setup.

The keyless endpoint needs the first behavior without the second.

## What changed

- Adds a profile-level `advertiseOAuth` decision
- Disables FastMCP OAuth discovery only for the anonymous `/v2/mcp` profile
- Keeps OAuth discovery enabled on `/v2/mcp-oauth` and `/v2/mcp-search`
- Keeps valid API keys working on `/v2/mcp`
- Keeps existing valid OAuth tokens working on `/v2/mcp`
- Removes `resource_metadata` from invalid-token challenges on the keyless endpoint so they do not invite a new OAuth flow
- Keeps the account endpoint's path-scoped OAuth metadata and API-key compatibility

## Behavior after this change

| Endpoint | Anonymous | API key | Existing OAuth token | Publishes OAuth discovery |
| --- | --- | --- | --- | --- |
| `/v2/mcp` | Yes | Yes | Yes, with the existing valid audience | No |
| `/v2/mcp-oauth` | No | Yes | Yes | Yes |
| `/v2/mcp-search` | No | Profile-dependent as before | Yes | Yes |

## Validation

- `npx tsc --noEmit`
- `npm run lint`
- `npm test` (66 passing)
- `git diff --check`
- Direct Codex CLI 0.146.0 test against the patched local server

Direct Codex result:

```text
$ codex mcp add firecrawl --url http://127.0.0.1:<port>/v2/mcp
Added global MCP server 'firecrawl'.
```

The local protected-resource metadata request returned 404, anonymous initialize remained successful, and Codex emitted no OAuth, browser, authorization, or login message.

## Review focus

- Compatibility impact of removing discovery metadata from `/v2/mcp`
- Confirmation that accepting existing OAuth tokens without advertising new OAuth is the intended migration behavior
- Deployment monitoring for Codex setup, anonymous initialize, account-door login, and existing bearer-token use

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788776827&installation_model_id=11126&pr_number=364&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F364&signature=676b70f9230bce76b20d61d5eb4f99ce2d658ad22c9f14ad4de3e45c30794432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop keyless MCP setup from starting OAuth. Anonymous `/v2/mcp` no longer publishes OAuth discovery, while OAuth-only surfaces still do.

- **Bug Fixes**
  - Added `advertiseOAuth` profile flag to decouple accepting credentials from advertising OAuth.
  - Disabled OAuth discovery for `/v2/mcp`; kept it enabled for `/v2/mcp-oauth` and `/v2/mcp-search`.
  - Kept API keys and existing OAuth tokens working on `/v2/mcp`.
  - Removed `resource_metadata` from 401 challenges on `/v2/mcp` to avoid prompting login.

<sup>Written for commit 7855049179d15a2d9d20981a5d043487d4d490c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

