### PR TITLE
research: tolerate removal of internal response fields

### DIFF
--- a/src/developer.ts
+++ b/src/developer.ts
@@ -44,8 +44,6 @@ const MAX_PASSAGE_CHARS = 1200;
 interface DeveloperHit {
   /** Stable result id, e.g. `issue:owner/repo#123` or `doc:<hash>`. */
   id?: string;
-  /** Result kind: `issue`, `pull_request`, `readme`, or `doc`. */
-  type?: string;
   url?: string;
   title?: string;
   /** Matched passages in markdown. */
@@ -53,16 +51,17 @@ interface DeveloperHit {
 }
 
 /**
- * Render developer hits as `## [id] (type) title` / url / passages blocks —
- * the same shape as the research formatters. Markdown passages keep their
- * newlines so tables and code survive.
+ * Render developer hits as `## [id] (kind) title` / url / passages blocks.
+ * The stable ID prefix supplies the kind. Markdown passages keep newlines.
  */
 function fmtDeveloper(results?: DeveloperHit[]): string {
   if (!results || results.length === 0) return '(no results)';
   return results
     .map((r) => {
-      const kind = r.type ? ` (${r.type})` : '';
-      const lines = [`## [${r.id ?? '?'}]${kind} ${r.title ?? '(untitled)'}`];
+      const id = r.id ?? '?';
+      const kind = r.id?.split(':', 1)[0];
+      const kindLabel = kind ? ` (${kind})` : '';
+      const lines = [`## [${id}]${kindLabel} ${r.title ?? '(untitled)'}`];
       if (r.url) lines.push(r.url);
       const body = (r.passages ?? [])
         .map((p) => p.text ?? '')

--- a/src/research.ts
+++ b/src/research.ts
@@ -176,7 +176,6 @@ function fmtPaperMetadata(paper?: PaperHit): string {
 const MAX_GITHUB_CONTENT_CHARS = 1200;
 
 interface GitHubItem {
-  resultType?: string;
   /** `owner/name`. */
   repo?: string;
   url?: string;
@@ -205,7 +204,7 @@ function fmtGithub(results?: GitHubItem[]): string {
   return results
     .map((r) => {
       const lines: string[] = [];
-      if (r.resultType === 'repo_readme') {
+      if (r.number == null && r.pageType == null) {
         lines.push(`[${r.repo ?? '?'}] README`);
       } else {
         const ref = r.number != null ? `#${r.number}` : '';


### PR DESCRIPTION
## What

- Detect README rows from public history fields.
- Derive developer result labels from stable ID prefixes.
- Keep the user output format unchanged.

## Why

- The server removes internal mechanism fields.
- The README label must remain after this change.

## Verified absent

- The source has no response-field references to `coverage`, `reranked`, or `variant`.
- The source has no references to `resultType` or `textKind`.

## Not touched

- This change does not alter request parameters or result content.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes reliance on server-only response fields so the developer and research formatters keep working after the API drops them. README rows and result kind labels are now inferred from stable IDs and public fields; user-facing output stays the same.

- **Refactors**
  - `developer.ts`: derive kind from `id` prefix; stop using `type`.
  - `research.ts`: detect README when `number` and `pageType` are absent; stop branching on `resultType`.

<sup>Written for commit 3f7a4d623d20bef5903b225c61c4bda5a32beb9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

