### PR TITLE
fix(mcp): put keyless account recovery in the agent-readable message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,15 +173,8 @@ const DEFAULT_MCP_SEARCH_ENDPOINT = '/v2/mcp-search';
 // MCP_CONNECTION_GUIDE_URL stays a stable, neutral entry point even while the
 // docs routing evolves; do not bind recovery payloads to an auth-mode leaf
 // page. It is a human-facing guide, not an MCP endpoint.
-// MCP_OAUTH_SERVER_URL intentionally repeats the value of
-// DEFAULT_MCP_OAUTH_RESOURCE_URL without aliasing it: the resource constant is
-// protocol identity and can be overridden per deployment via
-// FIRECRAWL_MCP_RESOURCE_URL, while this one is the fixed value a human puts
-// in MCP client settings for the hosted service.
 const MCP_CONNECTION_GUIDE_URL =
   'https://docs.firecrawl.dev/mcp-server';
-const MCP_OAUTH_SERVER_URL = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
-const API_KEY_SIGNUP_URL = 'https://www.firecrawl.dev/app/api-keys';
 
 function withoutTrailingSlash(value: string): string {
   return value.replace(/\/+$/, '');
@@ -251,6 +244,9 @@ function createOAuthChallengeResponse(
 
   const errorMessage =
     error instanceof Error ? error.message : String(error || 'Unauthorized');
+  // WWW-Authenticate is one header. Flatten CR/LF so a multiline JSON
+  // message cannot split the header value.
+  const wwwAuthenticateDescription = errorMessage.replace(/[\r\n]+/g, ' ').trim();
   const wwwAuthenticate = [
     ...(profile.advertiseOAuth
       ? [
@@ -258,7 +254,7 @@ function createOAuthChallengeResponse(
         ]
       : []),
     'error="invalid_token"',
-    `error_description="${escapeWWWAuthenticateValue(errorMessage)}"`,
+    `error_description="${escapeWWWAuthenticateValue(wwwAuthenticateDescription)}"`,
   ].join(', ');
 
   return new Response(
@@ -722,7 +718,7 @@ function makeAuthenticate(profile: ServerProfile) {
           throw createInvalidCredentialResponse(error);
         }
         if (error instanceof InvalidOAuthCredentialError) {
-          const recovery = invalidOAuthRecoveryPayload(profile);
+          const recovery = invalidOAuthRecoveryPayload();
           const oauthChallenge = createOAuthChallengeResponse(
             new Error(recovery.message),
             profile,
@@ -1023,59 +1019,29 @@ function isLocalKeylessStartup(): boolean {
   );
 }
 
-// Shared security-boundary phrasing: the API key must never pass through
-// chat/MCP URLs, and any recovery only takes effect on the next session/run.
-// Keep these as the single source of truth so every recovery/guidance string
-// that needs them composes from here instead of re-typing the wording.
-const NEVER_SHARE_API_KEY_SENTENCE =
-  'Never ask for, accept, or put an API key in chat or in an MCP URL.';
-const RETRY_AFTER_CONFIRM_SUFFIX =
-  'start a new client session or run and retry the original task.';
+// FastMCP copies UserError.message onto both content[0].text and
+// structuredContent.message. Hosts forward the text block, not
+// structured next_actions, so bearer and OAuth recovery strings live here.
+const KEYLESS_ACCOUNT_FIX =
+  'Fix: Create an API key at https://www.firecrawl.dev/signin , then either:\n- Set the header: Authorization: Bearer YOUR_API_KEY on https://mcp.firecrawl.dev/v2/mcp\n- Or use the URL: https://mcp.firecrawl.dev/v2/mcp-oauth\nThen start a new session.';
+const KEYLESS_QUOTA_MESSAGE = `You've hit Firecrawl's free MCP rate limit. To continue using without limits, create a Firecrawl API key.\n\n${KEYLESS_ACCOUNT_FIX}`;
+const KEYLESS_TOOL_MESSAGE = `This tool needs a Firecrawl account.\n\n${KEYLESS_ACCOUNT_FIX}`;
+const KEYLESS_ACCESS_MESSAGE = `Anonymous keyless access is unavailable for this request.\n\n${KEYLESS_ACCOUNT_FIX}`;
+const INVALID_API_KEY_MESSAGE =
+  'The Firecrawl API key is invalid or revoked.\nFix: Replace the key on the existing Firecrawl MCP server, then start a new session. Get an API key at https://www.firecrawl.dev/app/api-keys';
+const INVALID_OAUTH_MESSAGE =
+  'This Firecrawl account connection is no longer valid.\nFix: Reconnect the existing Firecrawl server in the client, or set that existing server URL to https://mcp.firecrawl.dev/v2/mcp-oauth, then start a new session.';
 
-const HUMAN_CONNECTION_GUIDANCE =
-  `A human or operator must complete the connection because this session cannot reconnect Firecrawl itself. Ask the human to choose before changing anything: (1) in the MCP client's settings, update or replace the existing Firecrawl server entry so its URL is ${MCP_OAUTH_SERVER_URL}, then complete sign-in through the client. That URL is a client configuration value, not a page to open in a browser. Do not add a second Firecrawl server or change configuration without approval; or (2) have an operator create an API key at ${API_KEY_SIGNUP_URL} and configure it in the client or secret manager outside this chat. ${NEVER_SHARE_API_KEY_SENTENCE} After the human confirms setup, ${RETRY_AFTER_CONFIRM_SUFFIX} Connection guide: ${MCP_CONNECTION_GUIDE_URL}`;
-
-const ACCOUNT_ONLY_TOOL_GUIDANCE =
-  `This tool needs a connected Firecrawl account. Search, Scrape, and Parse remain available, so continue with those if they can complete the task. Only if this task specifically requires this tool, tell the user that a human must update the existing Firecrawl connection using ${MCP_CONNECTION_GUIDE_URL}. Never ask for or accept an API key in chat. After setup, start a new client session and retry.`;
-
-const HUMAN_RECONNECT_ACCOUNT_ACTION = {
-  kind: 'human_reconnect_account',
-  actor: 'human',
-  requires_user_consent: true,
-  existing_server_only: true,
-  server_url: MCP_OAUTH_SERVER_URL,
-  open_server_url_in_browser: false,
-  docs_url: MCP_CONNECTION_GUIDE_URL,
-} as const;
-
-const OPERATOR_CONFIGURE_API_KEY_ACTION = {
-  kind: 'operator_configure_api_key',
-  actor: 'human_or_operator',
-  requires_user_consent: true,
-  credential_delivery: 'outside_agent_chat',
-  signup_url: API_KEY_SIGNUP_URL,
-} as const;
-
-const HUMAN_CONNECTION_ACTIONS = [
-  HUMAN_RECONNECT_ACCOUNT_ACTION,
-  OPERATOR_CONFIGURE_API_KEY_ACTION,
-] as const;
-
-// Shared shape for the two "existing connection is invalid" recovery
-// payloads below: same code/auth_mode/docs_url/next_actions fields, only the
-// message and next_actions ordering differ per credential type.
 function connectionRecoveryPayload(params: {
   code: string;
   authMode: string;
   message: string;
-  nextActions: readonly unknown[];
 }): Record<string, unknown> & { message: string } {
   return {
     code: params.code,
     auth_mode: params.authMode,
     message: params.message,
     docs_url: MCP_CONNECTION_GUIDE_URL,
-    next_actions: params.nextActions,
   };
 }
 
@@ -1083,34 +1049,15 @@ function invalidApiKeyRecoveryPayload(): Record<string, unknown> & { message: st
   return connectionRecoveryPayload({
     code: 'CREDENTIAL_INVALID',
     authMode: 'api_key',
-    message:
-      `The Firecrawl API key configured for this server is invalid or revoked. Ask a human or operator to replace it in this existing server configuration or secret manager outside this chat. ${NEVER_SHARE_API_KEY_SENTENCE} After the human confirms the change, ${RETRY_AFTER_CONFIRM_SUFFIX}`,
-    nextActions: [OPERATOR_CONFIGURE_API_KEY_ACTION],
+    message: INVALID_API_KEY_MESSAGE,
   });
 }
 
-function invalidOAuthRecoveryPayload(
-  profile: ServerProfile
-): Record<string, unknown> & { message: string } {
-  // The reconnect-through-this-client message is only true when OAuth is
-  // globally enabled AND this profile advertises it; otherwise fall through to
-  // the guidance for servers that do not start account sign-in.
-  if (isMcpOAuthEnabled() && profile.advertiseOAuth) {
-    return connectionRecoveryPayload({
-      code: 'OAUTH_CONNECTION_INVALID',
-      authMode: 'oauth',
-      message:
-        `This Firecrawl account connection is no longer valid. Ask the human to sign in again through this MCP client's account-connection flow. Do not add a second Firecrawl server or open the MCP server URL directly in a browser. After sign-in, ${RETRY_AFTER_CONFIRM_SUFFIX}`,
-      nextActions: [HUMAN_RECONNECT_ACCOUNT_ACTION, OPERATOR_CONFIGURE_API_KEY_ACTION],
-    });
-  }
-
+function invalidOAuthRecoveryPayload(): Record<string, unknown> & { message: string } {
   return connectionRecoveryPayload({
     code: 'OAUTH_CONNECTION_INVALID',
     authMode: 'oauth',
-    message:
-      `This Firecrawl account connection is no longer valid, and this server does not start account sign-in. Ask the human to choose before changing anything: (1) have an operator create a Firecrawl API key at ${API_KEY_SIGNUP_URL} and configure it on this existing server outside this chat; or (2) update this existing server's URL to ${MCP_OAUTH_SERVER_URL} and complete sign-in through the MCP client. That URL is a client configuration value, not a page to open in a browser. ${NEVER_SHARE_API_KEY_SENTENCE} After the human confirms the change, ${RETRY_AFTER_CONFIRM_SUFFIX}`,
-    nextActions: [OPERATOR_CONFIGURE_API_KEY_ACTION, HUMAN_RECONNECT_ACCOUNT_ACTION],
+    message: INVALID_OAUTH_MESSAGE,
   });
 }
 
@@ -1126,44 +1073,39 @@ function recoveryPayload(
   const isKeylessAccessUnavailable = code === 'KEYLESS_ACCESS_NOT_AVAILABLE';
   const isKeylessEligibilityUnavailable =
     code === 'KEYLESS_ELIGIBILITY_UNAVAILABLE';
+  const isKeylessConversion =
+    isQuotaExhausted || isToolUnavailable || isKeylessAccessUnavailable;
   return {
     code,
     request_id: requestId,
     auth_mode: code === 'CREDENTIAL_INVALID' ? 'credential_error' : 'keyless',
     message:
       code === 'CREDENTIAL_INVALID'
-        ? `The supplied Firecrawl credential is invalid or revoked. ${HUMAN_CONNECTION_GUIDANCE}`
+        ? INVALID_API_KEY_MESSAGE
         : isQuotaExhausted
-          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now: ${HUMAN_CONNECTION_GUIDANCE}`
+          ? KEYLESS_QUOTA_MESSAGE
           : isToolUnavailable
-            ? ACCOUNT_ONLY_TOOL_GUIDANCE
+            ? KEYLESS_TOOL_MESSAGE
             : isKeylessAccessUnavailable
-              ? `Anonymous keyless access is unavailable for this request. To continue: ${HUMAN_CONNECTION_GUIDANCE}`
+              ? KEYLESS_ACCESS_MESSAGE
               : isKeylessEligibilityUnavailable
                 ? 'The anonymous keyless eligibility check is temporarily unavailable. Retry shortly.'
-              : `This tool requires a Firecrawl account or API key. ${HUMAN_CONNECTION_GUIDANCE}`,
+                : 'This tool requires a Firecrawl account or API key.',
     // CREDENTIAL_INVALID sessions gate every tool call (including keyless
     // tools) on the credentialError check before the keyless branch ever
     // runs, so none of KEYLESS_TOOL_NAMES are actually callable here. Listing
     // them as available_tools would send the agent into a retry loop against
-    // tools that will just return this same recovery payload.
-    ...(isKeylessAccessUnavailable || code === 'CREDENTIAL_INVALID'
+    // tools that will just return this same recovery payload. Quota, blocked
+    // tools, and ineligible access omit available_tools and next_actions for
+    // the same reason: those fields retry tools that cannot clear the error.
+    ...(isKeylessConversion || code === 'CREDENTIAL_INVALID'
       ? {}
       : { available_tools: [...KEYLESS_TOOL_NAMES] }),
     docs_url: MCP_CONNECTION_GUIDE_URL,
     ...(retryAfterSeconds ? { retry_after_seconds: retryAfterSeconds } : {}),
-    next_actions: isKeylessEligibilityUnavailable
-      ? [{ kind: 'retry_later', after_seconds: 30 }]
-      : isQuotaExhausted || isKeylessAccessUnavailable
-      ? HUMAN_CONNECTION_ACTIONS
-      : isToolUnavailable
-        ? [
-            { kind: 'continue_keyless', tools: [...KEYLESS_TOOL_NAMES] },
-            ...HUMAN_CONNECTION_ACTIONS,
-          ]
-        : [
-            ...HUMAN_CONNECTION_ACTIONS,
-          ],
+    ...(isKeylessEligibilityUnavailable
+      ? { next_actions: [{ kind: 'retry_later', after_seconds: 30 }] }
+      : {}),
   };
 }
 

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -35,6 +35,8 @@ const EXCLUDED_TOOLS = [
 
 const SEARCH_ENDPOINT = '/v2/mcp-search';
 const SEARCH_RESOURCE = 'https://mcp.firecrawl.dev/v2/mcp-search';
+const INVALID_API_KEY_MESSAGE =
+  'The Firecrawl API key is invalid or revoked.\nFix: Replace the key on the existing Firecrawl MCP server, then start a new session. Get an API key at https://www.firecrawl.dev/app/api-keys';
 
 async function getFreePort() {
   const server = net.createServer();
@@ -499,9 +501,11 @@ test('search surface rejects an invalid raw API credential during tools/list', a
   const body = await res.json();
   assert.equal(body.error, 'invalid_api_key');
   assert.equal(body.code, 'CREDENTIAL_INVALID');
-  assert.match(body.error_description, /outside this chat/);
-  assert.equal(body.next_actions[0].kind, 'operator_configure_api_key');
-  assert.equal(body.next_actions[0].requires_user_consent, true);
+  assert.equal(
+    body.error_description,
+    INVALID_API_KEY_MESSAGE
+  );
+  assert.equal(body.next_actions, undefined);
 });
 
 test('search surface rejects an invalid raw API credential before a tool call', async (t) => {
@@ -525,9 +529,11 @@ test('search surface rejects an invalid raw API credential before a tool call', 
   const body = await res.json();
   assert.equal(body.error, 'invalid_api_key');
   assert.equal(body.code, 'CREDENTIAL_INVALID');
-  assert.match(body.error_description, /outside this chat/);
-  assert.equal(body.next_actions[0].kind, 'operator_configure_api_key');
-  assert.equal(body.next_actions[0].requires_user_consent, true);
+  assert.equal(
+    body.error_description,
+    INVALID_API_KEY_MESSAGE
+  );
+  assert.equal(body.next_actions, undefined);
   assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
 });
 

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -60,6 +60,47 @@ function assertServerGeneratedRequestId(payload, untrustedValues = []) {
   return payload.request_id;
 }
 
+const KEYLESS_ACCOUNT_FIX =
+  'Fix: Create an API key at https://www.firecrawl.dev/signin , then either:\n- Set the header: Authorization: Bearer YOUR_API_KEY on https://mcp.firecrawl.dev/v2/mcp\n- Or use the URL: https://mcp.firecrawl.dev/v2/mcp-oauth\nThen start a new session.';
+const KEYLESS_QUOTA_MESSAGE = `You've hit Firecrawl's free MCP rate limit. To continue using without limits, create a Firecrawl API key.\n\n${KEYLESS_ACCOUNT_FIX}`;
+const KEYLESS_TOOL_MESSAGE = `This tool needs a Firecrawl account.\n\n${KEYLESS_ACCOUNT_FIX}`;
+const KEYLESS_ACCESS_MESSAGE = `Anonymous keyless access is unavailable for this request.\n\n${KEYLESS_ACCOUNT_FIX}`;
+const INVALID_API_KEY_MESSAGE =
+  'The Firecrawl API key is invalid or revoked.\nFix: Replace the key on the existing Firecrawl MCP server, then start a new session. Get an API key at https://www.firecrawl.dev/app/api-keys';
+const INVALID_OAUTH_MESSAGE =
+  'This Firecrawl account connection is no longer valid.\nFix: Reconnect the existing Firecrawl server in the client, or set that existing server URL to https://mcp.firecrawl.dev/v2/mcp-oauth, then start a new session.';
+
+function assertKeylessAccountRecovery(
+  result,
+  { code, message, retryAfterSeconds, untrustedRequestIds = [] }
+) {
+  assert.equal(result.isError, true);
+  assert.equal(result.content[0].type, 'text');
+  assert.equal(result.content[0].text, message);
+  assert.equal(result.content[0].text, result.structuredContent.message);
+  assert.equal(result.structuredContent.code, code);
+  assert.equal(result.structuredContent.auth_mode, 'keyless');
+  assert.equal(result.structuredContent.message, message);
+  assert.equal(
+    result.structuredContent.docs_url,
+    'https://docs.firecrawl.dev/mcp-server'
+  );
+  assert.equal(result.structuredContent.available_tools, undefined);
+  assert.equal(result.structuredContent.next_actions, undefined);
+  assert.doesNotMatch(result.content[0].text, /ask the human/i);
+  assert.doesNotMatch(result.content[0].text, /never ask/i);
+  assert.doesNotMatch(result.content[0].text, /outside this chat/i);
+  assert.doesNotMatch(result.content[0].text, /must complete the connection/i);
+  assert.doesNotMatch(result.content[0].text, /try again in about/);
+  assert.doesNotMatch(result.content[0].text, /remain available/);
+  assert.doesNotMatch(result.content[0].text, /continue with those/);
+  assert.equal(result.structuredContent.retry_after_seconds, retryAfterSeconds);
+  assertServerGeneratedRequestId(
+    result.structuredContent,
+    untrustedRequestIds
+  );
+}
+
 function spawnServer(env) {
   const child = spawn(process.execPath, ['dist/index.js'], {
     env: {
@@ -948,27 +989,12 @@ test('HTTP cloud keyless transport rejects inactive OAuth without advertising lo
   assert.equal(body.error, 'invalid_token');
   assert.equal(body.code, 'OAUTH_CONNECTION_INVALID');
   assert.equal(body.auth_mode, 'oauth');
-  assert.match(body.error_description, /server does not start account sign-in/);
-  assert.match(body.error_description, /client configuration value, not a page to open/);
+  assert.equal(
+    body.error_description,
+    INVALID_OAUTH_MESSAGE
+  );
+  assert.equal(body.next_actions, undefined);
   assert.doesNotMatch(body.error_description, /Authorization: Bearer/);
-  assert.deepEqual(body.next_actions, [
-    {
-      kind: 'operator_configure_api_key',
-      actor: 'human_or_operator',
-      requires_user_consent: true,
-      credential_delivery: 'outside_agent_chat',
-      signup_url: 'https://www.firecrawl.dev/app/api-keys',
-    },
-    {
-      kind: 'human_reconnect_account',
-      actor: 'human',
-      requires_user_consent: true,
-      existing_server_only: true,
-      server_url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
-      open_server_url_in_browser: false,
-      docs_url: 'https://docs.firecrawl.dev/mcp-server',
-    },
-  ]);
   // The failed introspection must NOT leak downstream as an API call.
   assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
   assert.equal(stderr.includes('TypeError'), false, stderr);
@@ -1008,11 +1034,11 @@ test('HTTP transport returns invalid OAuth recovery without an OAuth challenge w
   assert.equal(body.error, 'invalid_token');
   assert.equal(body.code, 'OAUTH_CONNECTION_INVALID');
   assert.equal(body.auth_mode, 'oauth');
-  assert.match(body.error_description, /account connection is no longer valid/);
-  assert.match(
+  assert.equal(
     body.error_description,
-    /Never ask for, accept, or put an API key in chat/
+    INVALID_OAUTH_MESSAGE
   );
+  assert.equal(body.next_actions, undefined);
   assert.equal(backend.requests.some((request) => request.url === '/v2/search'), false);
 });
 
@@ -1139,7 +1165,7 @@ test('HTTP cloud keyless returns retry recovery when eligibility is unavailable'
   assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
 });
 
-test('HTTP cloud keyless continues with free-tier tools when an account-only tool is selected', async (t) => {
+test('HTTP cloud keyless blocks account-only tools instead of continuing keyless', async (t) => {
   const backend = await startFakeFirecrawlBackend({ keylessEligible: true });
   t.after(() => backend.close());
   const port = await getFreePort();
@@ -1163,56 +1189,51 @@ test('HTTP cloud keyless continues with free-tier tools when an account-only too
     },
   });
   const result = parseSseJson(await response.text()).result;
-  assert.equal(result.isError, true);
-  assert.equal(result.structuredContent.code, 'KEYLESS_TOOL_NOT_AVAILABLE');
-  assert.deepEqual(result.structuredContent.next_actions, [
-    {
-      kind: 'continue_keyless',
-      tools: ['firecrawl_scrape', 'firecrawl_search', 'firecrawl_parse'],
-    },
-    {
-      kind: 'human_reconnect_account',
-      actor: 'human',
-      requires_user_consent: true,
-      existing_server_only: true,
-      server_url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
-      open_server_url_in_browser: false,
-      docs_url: 'https://docs.firecrawl.dev/mcp-server',
-    },
-    {
-      kind: 'operator_configure_api_key',
-      actor: 'human_or_operator',
-      requires_user_consent: true,
-      credential_delivery: 'outside_agent_chat',
-      signup_url: 'https://www.firecrawl.dev/app/api-keys',
-    },
-  ]);
-  assert.deepEqual(result.structuredContent.available_tools, [
-    'firecrawl_scrape',
-    'firecrawl_search',
-    'firecrawl_parse',
-  ]);
-  assert.match(result.content[0].text, /Search, Scrape, and Parse remain available/);
-  assert.match(result.content[0].text, /continue with those if they can complete the task/);
-  assert.match(result.content[0].text, /Only if this task specifically requires this tool/);
-  assert.match(result.content[0].text, /https:\/\/docs\.firecrawl\.dev\/mcp-server/);
-  assert.match(result.content[0].text, /Never ask for or accept an API key in chat/);
-  assert.match(result.content[0].text, /new client session and retry/);
-  assert.doesNotMatch(result.content[0].text, /mcp\.firecrawl\.dev\/v2\/mcp-oauth/);
-  assert.doesNotMatch(result.content[0].text, /no action is required/);
-  assert.doesNotMatch(result.content[0].text, /Authorization: Bearer/);
+  assertKeylessAccountRecovery(result, {
+    code: 'KEYLESS_TOOL_NOT_AVAILABLE',
+    message: KEYLESS_TOOL_MESSAGE,
+  });
+  assert.doesNotMatch(result.content[0].text, /remain available/);
+  assert.doesNotMatch(result.content[0].text, /continue with those/);
   assert.equal(backend.requests.some((r) => r.url === '/v2/crawl'), false);
 });
 
-test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', async (t) => {
-  for (const [label, body, expectedCode] of [
-    ['with-reason', { error: 'limit', reason: 'credits', retry_after_seconds: 42 }, 'KEYLESS_QUOTA_EXHAUSTED'],
-    ['without-reason', { error: 'limit' }, 'KEYLESS_LIMIT_REACHED'],
+test('HTTP cloud keyless quota stays 200 isError without inlining retry_after_seconds', async (t) => {
+  for (const [label, backendOptions, expectedCode, retryAfterSeconds] of [
+    [
+      'core-with-reason',
+      {
+        keylessEligible: true,
+        searchResponse: {
+          status: 429,
+          body: { error: 'limit', reason: 'credits', retry_after_seconds: 42 },
+        },
+      },
+      'KEYLESS_QUOTA_EXHAUSTED',
+      42,
+    ],
+    [
+      'core-without-reason',
+      {
+        keylessEligible: true,
+        searchResponse: { status: 429, body: { error: 'limit' } },
+      },
+      'KEYLESS_LIMIT_REACHED',
+      undefined,
+    ],
+    [
+      'eligibility-exhausted',
+      {
+        keylessEligibilityResponse: {
+          status: 200,
+          body: { eligible: false, reason: 'credits', retryAfterSeconds: 42 },
+        },
+      },
+      'KEYLESS_QUOTA_EXHAUSTED',
+      42,
+    ],
   ]) {
-    const backend = await startFakeFirecrawlBackend({
-      keylessEligible: true,
-      searchResponse: { status: 429, body },
-    });
+    const backend = await startFakeFirecrawlBackend(backendOptions);
     const port = await getFreePort();
     const child = spawnServer({
       CLOUD_SERVICE: 'true',
@@ -1236,43 +1257,15 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
       headers: { 'x-forwarded-for': '8.8.8.7' },
       params: { arguments: { limit: 1, query: 'example domain' }, name: 'firecrawl_search' },
     });
+    assert.equal(response.status, 200, label);
     const result = parseSseJson(await response.text()).result;
-    assert.equal(result.isError, true, label);
-    assert.equal(result.structuredContent.code, expectedCode, label);
-    assert.deepEqual(result.structuredContent.next_actions, [
-      {
-        kind: 'human_reconnect_account',
-        actor: 'human',
-        requires_user_consent: true,
-        existing_server_only: true,
-        server_url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
-        open_server_url_in_browser: false,
-        docs_url:
-          'https://docs.firecrawl.dev/mcp-server',
-      },
-      {
-        kind: 'operator_configure_api_key',
-        actor: 'human_or_operator',
-        requires_user_consent: true,
-        credential_delivery: 'outside_agent_chat',
-        signup_url: 'https://www.firecrawl.dev/app/api-keys',
-      },
-    ], label);
-    assert.match(result.content[0].text, /Ask the human to choose/, label);
-    assert.match(result.content[0].text, /update or replace the existing Firecrawl server entry/, label);
-    assert.match(result.content[0].text, /client configuration value, not a page to open/, label);
-    assert.match(result.content[0].text, /outside this chat/, label);
-    assert.match(result.content[0].text, /new client session or run/, label);
-    // The OAuth endpoint must be present and explicitly framed as configuration.
-    // This is the inverse of the earlier no-endpoint recovery contract.
-    assert.match(result.content[0].text, /mcp\.firecrawl\.dev\/v2\/mcp-oauth/, label);
-    assert.match(result.content[0].text, /docs\.firecrawl\.dev\/mcp-server(?:\s|$)/, label);
-    assert.doesNotMatch(result.content[0].text, /Authorization: Bearer/, label);
+    assertKeylessAccountRecovery(result, {
+      code: expectedCode,
+      message: KEYLESS_QUOTA_MESSAGE,
+      retryAfterSeconds,
+    });
+    assert.doesNotMatch(result.content[0].text, /about 42 seconds/, label);
     assert.doesNotMatch(result.content[0].text, /claude mcp add/, label);
-    if (label === 'with-reason') {
-      assert.equal(result.structuredContent.retry_after_seconds, 42);
-      assert.match(result.content[0].text, /about 42 seconds/);
-    }
     await cleanup();
   }
 });
@@ -1433,11 +1426,10 @@ test('HTTP cloud keyless rejects multi-hop or malformed forwarded IP identity', 
     });
     assert.equal(response.status, 200, xff);
     const result = parseSseJson(await response.text()).result;
-    assert.equal(result.isError, true, xff);
-    assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE', xff);
-    assert.equal(result.structuredContent.next_actions[0].kind, 'human_reconnect_account', xff);
-    assert.equal(result.structuredContent.next_actions[0].actor, 'human', xff);
-    assert.equal(result.structuredContent.available_tools, undefined, xff);
+    assertKeylessAccountRecovery(result, {
+      code: 'KEYLESS_ACCESS_NOT_AVAILABLE',
+      message: KEYLESS_ACCESS_MESSAGE,
+    });
   }
   assert.equal(backend.requests.length, 0, JSON.stringify(backend.requests));
 });
@@ -1587,15 +1579,14 @@ test('HTTP cloud transport returns recovery when keyless identity has no client 
   });
   assert.equal(toolCall.status, 200);
   const result = parseSseJson(await toolCall.text()).result;
-  assert.equal(result.isError, true);
-  assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE');
-  assert.equal(result.structuredContent.next_actions[0].kind, 'human_reconnect_account');
-  assert.equal(result.structuredContent.next_actions[0].actor, 'human');
-  assert.equal(result.structuredContent.available_tools, undefined);
-  assertServerGeneratedRequestId(result.structuredContent, [
-    'client-json-rpc-id',
-    'client-request-header-id',
-  ]);
+  assertKeylessAccountRecovery(result, {
+    code: 'KEYLESS_ACCESS_NOT_AVAILABLE',
+    message: KEYLESS_ACCESS_MESSAGE,
+    untrustedRequestIds: [
+      'client-json-rpc-id',
+      'client-request-header-id',
+    ],
+  });
   assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
@@ -1722,11 +1713,11 @@ test('account endpoint keeps OAuth discovery and gives safe re-auth guidance for
   assert.equal(body.error, 'invalid_token');
   assert.equal(body.code, 'OAUTH_CONNECTION_INVALID');
   assert.equal(body.auth_mode, 'oauth');
-  assert.match(body.error_description, /sign in again through this MCP client's account-connection flow/);
-  assert.match(body.error_description, /start a new client session or run/);
-  assert.equal(body.next_actions[0].kind, 'human_reconnect_account');
-  assert.equal(body.next_actions[0].requires_user_consent, true);
-  assert.equal(body.next_actions[1].kind, 'operator_configure_api_key');
+  assert.equal(
+    body.error_description,
+    INVALID_OAUTH_MESSAGE
+  );
+  assert.equal(body.next_actions, undefined);
   assert.equal(backend.requests.some((request) => request.url === '/v2/search'), false);
 });
 
@@ -2137,21 +2128,15 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
   const invalidCallJson = parseSseJson(await invalidCall.text());
   const invalidRecovery = invalidCallJson.result.structuredContent;
   assert.equal(invalidCallJson.result.isError, true);
+  assert.equal(invalidCallJson.result.content[0].text, INVALID_API_KEY_MESSAGE);
   assert.equal(invalidRecovery.code, 'CREDENTIAL_INVALID');
-  assert.match(invalidRecovery.message, /invalid or revoked/);
-  // The consent-first boundary must survive: never route the key through chat.
-  assert.match(
-    invalidRecovery.message,
-    /Never ask for, accept, or put an API key in chat/
-  );
-  // Recovery pins the concrete next-action contract: reconnect (human) then
-  // operator-configure, each with its consent flag, not just a non-empty array.
-  assert.equal(invalidRecovery.next_actions[0].kind, 'human_reconnect_account');
-  assert.equal(invalidRecovery.next_actions[0].actor, 'human');
-  assert.equal(invalidRecovery.next_actions[0].requires_user_consent, true);
-  assert.equal(invalidRecovery.next_actions[1].kind, 'operator_configure_api_key');
-  assert.equal(invalidRecovery.next_actions[1].actor, 'human_or_operator');
-  assert.equal(invalidRecovery.next_actions[1].requires_user_consent, true);
+  assert.equal(invalidRecovery.message, INVALID_API_KEY_MESSAGE);
+  assert.equal(invalidCallJson.result.content[0].text, invalidRecovery.message);
+  assert.equal(invalidRecovery.next_actions, undefined);
+  assert.doesNotMatch(invalidRecovery.message, /ask the human/i);
+  assert.doesNotMatch(invalidRecovery.message, /never ask/i);
+  assert.doesNotMatch(invalidRecovery.message, /outside this chat/i);
+  assert.doesNotMatch(invalidRecovery.message, /Authorization: Bearer/);
   // No tool is actually callable in a credentialError session (the
   // credentialError check gates execute() before the keyless branch), so the
   // payload must not advertise keyless tools as available.


### PR DESCRIPTION
## Why

Agents read `content[0].text` (`=== structuredContent.message`). Keyless quota, blocked-tool, and ineligible-access recoveries previously told the agent to keep using keyless tools or wait, so the account-attachment steps never reached that path.

## Summary

- Put both attachment routes in the shared keyless recovery `message`: create a key at `https://www.firecrawl.dev/signin`, then set `Authorization: Bearer YOUR_API_KEY` on `https://mcp.firecrawl.dev/v2/mcp` or use `https://mcp.firecrawl.dev/v2/mcp-oauth`.
- Apply that copy to `KEYLESS_QUOTA_EXHAUSTED`, `KEYLESS_LIMIT_REACHED`, `KEYLESS_TOOL_NOT_AVAILABLE`, and `KEYLESS_ACCESS_NOT_AVAILABLE`.
- Drop `available_tools` and `next_actions` (including `continue_keyless`) on those codes so the agent is not sent back into Search/Scrape/Parse.
- Keep `retry_after_seconds` on `structuredContent` when Core sends it; do not put a wait in the message.
- Leave `CREDENTIAL_INVALID`, `KEYLESS_ELIGIBILITY_UNAVAILABLE`, `KEYLESS_OPTION_NOT_AVAILABLE`, and `initialize` / `KEYLESS_PROFILE_INSTRUCTIONS` unchanged. The result stays a `200` `isError` tool result.

## Test plan

- [ ] `npm test`
- [ ] Keyless Search/Scrape/Parse 429 returns `isError: true` with the quota message and `content[0].text === structuredContent.message`
- [ ] `retry_after_seconds` is present only when the API body includes it
- [ ] Keyless `firecrawl_crawl` (and other account-only tools) returns `KEYLESS_TOOL_NOT_AVAILABLE` with no `available_tools` / `continue_keyless`
- [ ] Ineligible keyless IP returns `KEYLESS_ACCESS_NOT_AVAILABLE` with the same Fix
- [ ] Invalid API key recovery and eligibility-unavailable retry guidance are unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves keyless and invalid-credential recovery into the agent-visible message with short Fix steps, removing structured retries that sent agents into loops.

- KEYLESS_QUOTA_EXHAUSTED, KEYLESS_LIMIT_REACHED, KEYLESS_TOOL_NOT_AVAILABLE, KEYLESS_ACCESS_NOT_AVAILABLE: show a short Fix in content[0].text / structuredContent.message to create an API key at https://www.firecrawl.dev/signin and either set Authorization: Bearer YOUR_API_KEY on https://mcp.firecrawl.dev/v2/mcp or use https://mcp.firecrawl.dev/v2/mcp-oauth, then start a new session. Keep docs_url; include retry_after_seconds only when provided. Return a 200 isError tool result. Omit available_tools and next_actions.
- CREDENTIAL_INVALID: return a concise message to replace the API key on the existing server and start a new session. No next_actions.
- OAUTH_CONNECTION_INVALID: return a concise message to reconnect the existing server or set its URL to https://mcp.firecrawl.dev/v2/mcp-oauth, then start a new session. WWW-Authenticate error_description is flattened to one line. No next_actions.
- KEYLESS_ELIGIBILITY_UNAVAILABLE: still returns a retry‑later next_actions.
- content[0].text always equals structuredContent.message.

<sup>Written for commit 4c1da4ff5ac20d21a4ce2de15a0f4cd8cfb3f054. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

