### PR TITLE
developer: use server passage budget from search#843

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,8 +929,7 @@ Search an index built for coding agents. The index covers GitHub issues, merged 
   "arguments": {
     "query": "how do I configure retries",
     "k": 10,
-    "skills": "only",
-    "passage_budget": 4096
+    "skills": "only"
   }
 }
 ```
@@ -938,9 +937,6 @@ Search an index built for coding agents. The index covers GitHub issues, merged 
 - `query` (required): the developer question or search phrase.
 - `k`: number of ranked results. The default is 10 and the maximum is 100.
 - `skills`: set to `"only"` to search agent-skill files alone.
-- `passage_budget`: approximate-token budget allocated by the search server across all returned passages. The default is 4096 and the accepted range is 256–16384.
-
-The 4096-token default preserves the intent of the previous MCP output cap: 1200 characters were roughly 300 tokens per result, or about 3000 passage tokens across the default 10 results, with additional allocation headroom.
 
 **Returns:** Ranked results. Each result carries an ID, a source type (`issue`, `pull_request`, `readme`, or `doc`), a URL, a title, and the matched passages in markdown.
 

--- a/README.md
+++ b/README.md
@@ -929,7 +929,8 @@ Search an index built for coding agents. The index covers GitHub issues, merged 
   "arguments": {
     "query": "how do I configure retries",
     "k": 10,
-    "skills": "only"
+    "skills": "only",
+    "passage_budget": 4096
   }
 }
 ```
@@ -937,6 +938,9 @@ Search an index built for coding agents. The index covers GitHub issues, merged 
 - `query` (required): the developer question or search phrase.
 - `k`: number of ranked results. The default is 10 and the maximum is 100.
 - `skills`: set to `"only"` to search agent-skill files alone.
+- `passage_budget`: approximate-token budget allocated by the search server across all returned passages. The default is 4096 and the accepted range is 256–16384.
+
+The 4096-token default preserves the intent of the previous MCP output cap: 1200 characters were roughly 300 tokens per result, or about 3000 passage tokens across the default 10 results, with additional allocation headroom.
 
 **Returns:** Ranked results. Each result carries an ID, a source type (`issue`, `pull_request`, `readme`, or `doc`), a URL, a title, and the matched passages in markdown.
 

--- a/src/developer.ts
+++ b/src/developer.ts
@@ -36,7 +36,6 @@ type GetClient = (session?: SessionData) => unknown;
 const BASE = '/v2/search/developer';
 const ORIGIN_HEADERS = { 'X-Origin': 'mcp-fastmcp' };
 
-const DEFAULT_PASSAGE_BUDGET = 4096;
 const LEGACY_MAX_PASSAGE_CHARS = 1200;
 
 interface DeveloperHit {
@@ -116,31 +115,17 @@ Returns ranked results with an ID, source type, URL, title, and the matched pass
         .enum(['only'])
         .optional()
         .describe('Set to "only" to search only agent-skill files.'),
-      passage_budget: z
-        .number()
-        .int()
-        .min(256)
-        .max(16384)
-        .default(DEFAULT_PASSAGE_BUDGET)
-        .describe(
-          'Approximate-token budget allocated by the search server across all returned passages (default 4096). The old 1200-character cap was about 300 tokens per result, or about 3000 tokens across 10 default results; 4096 preserves that intent with allocation headroom.'
-        ),
     }),
     execute: async (args: unknown, { session }): Promise<string> => {
-      const { query, k, skills, passage_budget } = args as {
+      const { query, k, skills } = args as {
         query: string;
         k?: number;
         skills?: 'only';
-        passage_budget?: number;
       };
       const params = new URLSearchParams();
       params.append('query', query);
       if (k != null) params.append('k', String(k));
       if (skills != null) params.append('skills', skills);
-      params.append(
-        'passage_budget',
-        String(passage_budget ?? DEFAULT_PASSAGE_BUDGET)
-      );
       const client = getClient(session) as ClientLike;
       const res = await client.http.get<{
         results?: DeveloperHit[];

--- a/src/developer.ts
+++ b/src/developer.ts
@@ -36,10 +36,8 @@ type GetClient = (session?: SessionData) => unknown;
 const BASE = '/v2/search/developer';
 const ORIGIN_HEADERS = { 'X-Origin': 'mcp-fastmcp' };
 
-// Cap the matched passages per result so a page of hits stays within the MCP
-// output-token limit. Sized like the research GitHub content cap: passages
-// carry the signal (repro steps, stack traces, API contracts) the agent needs.
-const MAX_PASSAGE_CHARS = 1200;
+const DEFAULT_PASSAGE_BUDGET = 4096;
+const LEGACY_MAX_PASSAGE_CHARS = 1200;
 
 interface DeveloperHit {
   /** Stable result id, e.g. `issue:owner/repo#123` or `doc:<hash>`. */
@@ -54,7 +52,10 @@ interface DeveloperHit {
  * Render developer hits as `## [id] (kind) title` / url / passages blocks.
  * The stable ID prefix supplies the kind. Markdown passages keep newlines.
  */
-function fmtDeveloper(results?: DeveloperHit[]): string {
+function fmtDeveloper(
+  results?: DeveloperHit[],
+  passageBudgetApplied?: number
+): string {
   if (!results || results.length === 0) return '(no results)';
   return results
     .map((r) => {
@@ -67,7 +68,13 @@ function fmtDeveloper(results?: DeveloperHit[]): string {
         .map((p) => p.text ?? '')
         .join('\n---\n')
         .trim();
-      lines.push(body ? body.slice(0, MAX_PASSAGE_CHARS) : '(no content)');
+      // TODO(search#843): Remove this fallback after server passage budgeting
+      // is fully enabled.
+      const renderedBody =
+        passageBudgetApplied == null
+          ? body.slice(0, LEGACY_MAX_PASSAGE_CHARS)
+          : body;
+      lines.push(renderedBody || '(no content)');
       return lines.join('\n');
     })
     .join('\n\n');
@@ -109,23 +116,37 @@ Returns ranked results with an ID, source type, URL, title, and the matched pass
         .enum(['only'])
         .optional()
         .describe('Set to "only" to search only agent-skill files.'),
+      passage_budget: z
+        .number()
+        .int()
+        .min(256)
+        .max(16384)
+        .default(DEFAULT_PASSAGE_BUDGET)
+        .describe(
+          'Approximate-token budget allocated by the search server across all returned passages (default 4096). The old 1200-character cap was about 300 tokens per result, or about 3000 tokens across 10 default results; 4096 preserves that intent with allocation headroom.'
+        ),
     }),
     execute: async (args: unknown, { session }): Promise<string> => {
-      const { query, k, skills } = args as {
+      const { query, k, skills, passage_budget } = args as {
         query: string;
         k?: number;
         skills?: 'only';
+        passage_budget?: number;
       };
       const params = new URLSearchParams();
       params.append('query', query);
       if (k != null) params.append('k', String(k));
       if (skills != null) params.append('skills', skills);
-      const client = getClient(session) as ClientLike;
-      const res = await client.http.get<{ results?: DeveloperHit[] }>(
-        `${BASE}?${params.toString()}`,
-        ORIGIN_HEADERS
+      params.append(
+        'passage_budget',
+        String(passage_budget ?? DEFAULT_PASSAGE_BUDGET)
       );
-      return fmtDeveloper(res.data?.results);
+      const client = getClient(session) as ClientLike;
+      const res = await client.http.get<{
+        results?: DeveloperHit[];
+        passage_budget_applied?: number;
+      }>(`${BASE}?${params.toString()}`, ORIGIN_HEADERS);
+      return fmtDeveloper(res.data?.results, res.data?.passage_budget_applied);
     },
   });
 }

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -229,13 +229,12 @@ async function startFakeDeveloperApi() {
 
     const url = new URL(req.url ?? '/', 'http://127.0.0.1');
     if (req.method === 'GET' && url.pathname === '/v2/search/developer') {
-      const passageBudget = url.searchParams.get('passage_budget');
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(
         JSON.stringify({
           ...(url.searchParams.get('query') === 'legacy server'
             ? {}
-            : { passage_budget_applied: Number(passageBudget) }),
+            : { passage_budget_applied: 4096 }),
           results: [
             {
               id: 'doc:fixture',
@@ -920,19 +919,19 @@ test('developer search delegates passage cuts to the server with a legacy fallba
   });
   client.notify('notifications/initialized');
 
+  const tools = await client.request('tools/list');
+  const developerTool = tools.tools.find(
+    (tool) => tool.name === 'firecrawl_developer_search'
+  );
+  assert.ok(developerTool);
+  assert.equal('passage_budget' in developerTool.inputSchema.properties, false);
+
   const serverBudgeted = await client.request('tools/call', {
     arguments: { query: 'server budget' },
     name: 'firecrawl_developer_search',
   });
   assert.notEqual(serverBudgeted.isError, true);
   assert.ok(serverBudgeted.content[0].text.includes(fakeApi.passage));
-
-  const customBudget = await client.request('tools/call', {
-    arguments: { passage_budget: 768, query: 'custom budget' },
-    name: 'firecrawl_developer_search',
-  });
-  assert.notEqual(customBudget.isError, true);
-  assert.ok(customBudget.content[0].text.includes(fakeApi.passage));
 
   const legacy = await client.request('tools/call', {
     arguments: { query: 'legacy server' },
@@ -945,9 +944,8 @@ test('developer search delegates passage cuts to the server with a legacy fallba
   assert.deepEqual(
     fakeApi.requests.map((request) => request.url),
     [
-      '/v2/search/developer?query=server+budget&passage_budget=4096',
-      '/v2/search/developer?query=custom+budget&passage_budget=768',
-      '/v2/search/developer?query=legacy+server&passage_budget=4096',
+      '/v2/search/developer?query=server+budget',
+      '/v2/search/developer?query=legacy+server',
     ]
   );
 });

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -212,6 +212,66 @@ async function startFakeFirecrawlApi() {
   };
 }
 
+// A fake API that can emulate both server-budgeted and legacy developer
+// search responses.
+async function startFakeDeveloperApi() {
+  const requests = [];
+  const passage = 'x'.repeat(5000);
+  const server = createServer(async (req, res) => {
+    for await (const _chunk of req) {
+      // Drain the request before responding.
+    }
+    requests.push({
+      headers: req.headers,
+      method: req.method,
+      url: req.url,
+    });
+
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    if (req.method === 'GET' && url.pathname === '/v2/search/developer') {
+      const passageBudget = url.searchParams.get('passage_budget');
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          ...(url.searchParams.get('query') === 'legacy server'
+            ? {}
+            : { passage_budget_applied: Number(passageBudget) }),
+          results: [
+            {
+              id: 'doc:fixture',
+              passages: [{ text: passage }],
+              title: 'Developer fixture',
+              url: 'https://example.com/developer',
+            },
+          ],
+          success: true,
+        })
+      );
+      return;
+    }
+
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: `Unhandled ${req.method} ${req.url}` }));
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  assert.equal(typeof address, 'object');
+
+  return {
+    passage,
+    requests,
+    url: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
 // A single fake origin that stands in for BOTH the Firecrawl OAuth issuer
 // (token introspection + keyless eligibility) AND the Firecrawl API. Every
 // request is recorded so tests can assert what the MCP server forwarded.
@@ -840,6 +900,56 @@ test('monitor create gives queries precedence over page targets', async (t) => {
   assert.deepEqual(monitorRequests[1].body.targets, [
     { type: 'scrape', urls: ['https://example.com/retained'] },
   ]);
+});
+
+test('developer search delegates passage cuts to the server with a legacy fallback', async (t) => {
+  const fakeApi = await startFakeDeveloperApi();
+  t.after(() => fakeApi.close());
+
+  const child = spawnServer({
+    FIRECRAWL_API_KEY: 'fc-test',
+    FIRECRAWL_API_URL: fakeApi.url,
+  });
+  t.after(() => stopChild(child));
+
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'firecrawl-developer-budget', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+
+  const serverBudgeted = await client.request('tools/call', {
+    arguments: { query: 'server budget' },
+    name: 'firecrawl_developer_search',
+  });
+  assert.notEqual(serverBudgeted.isError, true);
+  assert.ok(serverBudgeted.content[0].text.includes(fakeApi.passage));
+
+  const customBudget = await client.request('tools/call', {
+    arguments: { passage_budget: 768, query: 'custom budget' },
+    name: 'firecrawl_developer_search',
+  });
+  assert.notEqual(customBudget.isError, true);
+  assert.ok(customBudget.content[0].text.includes(fakeApi.passage));
+
+  const legacy = await client.request('tools/call', {
+    arguments: { query: 'legacy server' },
+    name: 'firecrawl_developer_search',
+  });
+  assert.notEqual(legacy.isError, true);
+  const legacyBody = legacy.content[0].text.split('\n').slice(2).join('\n');
+  assert.equal(legacyBody.length, 1200);
+
+  assert.deepEqual(
+    fakeApi.requests.map((request) => request.url),
+    [
+      '/v2/search/developer?query=server+budget&passage_budget=4096',
+      '/v2/search/developer?query=custom+budget&passage_budget=768',
+      '/v2/search/developer?query=legacy+server&passage_budget=4096',
+    ]
+  );
 });
 
 test('stdio transport calls Firecrawl API through a tool end to end', async (t) => {


### PR DESCRIPTION
## Summary

- keep passage sizing as server-side policy, with no client knob
- remove `passage_budget` from the MCP tool schema and stop sending it on developer-search requests
- trust server-shaped passage text without a local cut when `passage_budget_applied` is present
- retain the 1,200-character fallback when that field is absent, covering old servers and rollout-off responses

Decision: **server-side policy, no client knob**.

The fallback retains the TODO to remove it after firecrawl/search#843 is enabled everywhere.

## Verification

- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` (72 passed)
