### PR TITLE
fix: constrain search limit schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -819,7 +819,7 @@ const searchToolBaseFields = {
     .describe(
       'Return query-relevant highlights for each search result. Set to false to keep the original search snippets.'
     ),
-  limit: z.number().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
   tbs: z.string().optional(),
   filter: z.string().optional(),
   location: z.string().optional(),

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -717,6 +717,9 @@ test('primary search profile uses the strict marketplace search tool, not the fu
   assert.ok(search, 'primary profile must register firecrawl_search');
   assert.doesNotMatch(JSON.stringify(search.inputSchema), /scrapeOptions/);
   assert.doesNotMatch(search.description ?? '', /search_feedback|refund/i);
+  assert.equal(search.inputSchema.properties.limit.type, 'integer');
+  assert.equal(search.inputSchema.properties.limit.minimum, 1);
+  assert.equal(search.inputSchema.properties.limit.maximum, 100);
 
   const response = await jsonRpc(port, SEARCH_ENDPOINT, {
     id: 13,

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -549,6 +549,9 @@ test('HTTP cloud keyless transport preserves app challenge without advertising O
   );
   assert.equal(searchTool.inputSchema.properties.highlights.type, 'boolean');
   assert.equal('default' in searchTool.inputSchema.properties.highlights, false);
+  assert.equal(searchTool.inputSchema.properties.limit.type, 'integer');
+  assert.equal(searchTool.inputSchema.properties.limit.minimum, 1);
+  assert.equal(searchTool.inputSchema.properties.limit.maximum, 100);
 
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
@@ -623,6 +626,49 @@ test('HTTP cloud transport calls Firecrawl API with authenticated session', asyn
     query: 'example domain',
   });
   assert.equal(stderr.includes('TypeError'), false, stderr);
+});
+
+test('HTTP cloud transport rejects invalid search limits before calling Firecrawl', async (t) => {
+  const fakeApi = await startFakeFirecrawlApi();
+  t.after(() => fakeApi.close());
+
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: fakeApi.url,
+    FIRECRAWL_OAUTH_ISSUER: fakeApi.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const searchRequestsBefore = fakeApi.requests.filter(
+    (request) => request.url === '/v2/search'
+  ).length;
+  for (const [index, limit] of [0, 1.5, 101].entries()) {
+    const response = await httpToolCall(port, {
+      id: 400 + index,
+      headers: { 'x-api-key': 'fc-test' },
+      params: {
+        arguments: { limit, query: 'invalid search limit' },
+        name: 'firecrawl_search',
+      },
+    });
+    assert.equal(response.status, 200);
+    const message = parseSseJson(await response.text());
+    assert.equal(
+      Boolean(message.error) || message.result?.isError === true,
+      true,
+      JSON.stringify(message)
+    );
+  }
+  const searchRequestsAfter = fakeApi.requests.filter(
+    (request) => request.url === '/v2/search'
+  ).length;
+  assert.equal(searchRequestsAfter, searchRequestsBefore);
 });
 
 class StdioMcpClient {


### PR DESCRIPTION
## Summary

- constrain `firecrawl_search.limit` to an integer from 1 through 100
- add schema regression coverage for the public search tool
- verify invalid limits are rejected before a Firecrawl API request is made

Fixes #376

## Testing

- `pnpm test` (73 passed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Constrain `firecrawl_search.limit` to an integer between 1 and 100 and reject invalid values before calling Firecrawl. Previously any number was accepted and could be sent to Firecrawl; now invalid limits return a validation error and no API request is made.

- Schema change: `limit: z.number().int().min(1).max(100).optional()`. Default behavior is unchanged when `limit` is omitted.
- Tests assert the input schema exposes integer/min/max and that `0`, `1.5`, and `101` are rejected pre-request.
- Migration: If you pass non-integer or out-of-range limits, update them to an integer in [1, 100].

<sup>Written for commit 3ae017fa20fe181bfa7a134542fccd16f5e664a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

