### PR TITLE
drop the legacy passage cap; passages are server-shaped

### DIFF
--- a/src/developer.ts
+++ b/src/developer.ts
@@ -36,7 +36,6 @@ type GetClient = (session?: SessionData) => unknown;
 const BASE = '/v2/search/developer';
 const ORIGIN_HEADERS = { 'X-Origin': 'mcp-fastmcp' };
 
-const LEGACY_MAX_PASSAGE_CHARS = 1200;
 
 interface DeveloperHit {
   /** Stable result id, e.g. `issue:owner/repo#123` or `doc:<hash>`. */
@@ -52,8 +51,7 @@ interface DeveloperHit {
  * The stable ID prefix supplies the kind. Markdown passages keep newlines.
  */
 function fmtDeveloper(
-  results?: DeveloperHit[],
-  passageBudgetApplied?: number
+  results?: DeveloperHit[]
 ): string {
   if (!results || results.length === 0) return '(no results)';
   return results
@@ -67,13 +65,9 @@ function fmtDeveloper(
         .map((p) => p.text ?? '')
         .join('\n---\n')
         .trim();
-      // TODO(search#843): Remove this fallback after server passage budgeting
-      // is fully enabled.
-      const renderedBody =
-        passageBudgetApplied == null
-          ? body.slice(0, LEGACY_MAX_PASSAGE_CHARS)
-          : body;
-      lines.push(renderedBody || '(no content)');
+      // Passages are server-shaped (search-side budget is always on); no
+      // client-side truncation.
+      lines.push(body || '(no content)');
       return lines.join('\n');
     })
     .join('\n\n');
@@ -129,9 +123,8 @@ Returns ranked results with an ID, source type, URL, title, and the matched pass
       const client = getClient(session) as ClientLike;
       const res = await client.http.get<{
         results?: DeveloperHit[];
-        passage_budget_applied?: number;
       }>(`${BASE}?${params.toString()}`, ORIGIN_HEADERS);
-      return fmtDeveloper(res.data?.results, res.data?.passage_budget_applied);
+      return fmtDeveloper(res.data?.results);
     },
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes legacy client-side passage truncation for developer search; passages are now shaped by the server. Previously we capped passages at 1200 chars when no budget was applied; now we always render the server-provided passage and ignore any `passage_budget_applied` flag.

- fmtDeveloper no longer accepts a budget argument; removes `LEGACY_MAX_PASSAGE_CHARS` and response handling for `passage_budget_applied`.
- Validate server-side passage budgeting is enabled in all environments; outputs may be longer if the server is misconfigured.

<sup>Written for commit 21603d03f5e3858cc807badfda542d48f4e795d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

