### PR TITLE
smoke: passages are uncapped in all cases

### DIFF
--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -901,7 +901,7 @@ test('monitor create gives queries precedence over page targets', async (t) => {
   ]);
 });
 
-test('developer search delegates passage cuts to the server with a legacy fallback', async (t) => {
+test('developer search serves server-shaped passages uncapped', async (t) => {
   const fakeApi = await startFakeDeveloperApi();
   t.after(() => fakeApi.close());
 
@@ -933,13 +933,14 @@ test('developer search delegates passage cuts to the server with a legacy fallba
   assert.notEqual(serverBudgeted.isError, true);
   assert.ok(serverBudgeted.content[0].text.includes(fakeApi.passage));
 
+  // No client-side cap in any case: even a response without
+  // passage_budget_applied (older server) serves the passage whole.
   const legacy = await client.request('tools/call', {
     arguments: { query: 'legacy server' },
     name: 'firecrawl_developer_search',
   });
   assert.notEqual(legacy.isError, true);
-  const legacyBody = legacy.content[0].text.split('\n').slice(2).join('\n');
-  assert.equal(legacyBody.length, 1200);
+  assert.ok(legacy.content[0].text.includes(fakeApi.passage));
 
   assert.deepEqual(
     fakeApi.requests.map((request) => request.url),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Developer search passages are now uncapped in all cases, including legacy servers that don’t set passage_budget_applied. Previously, legacy responses were truncated to 1200 characters; now the client returns the full server-shaped passage.

- Update `tests/mcp-smoke.test.mjs`: rename the test and assert full passage content for both budgeted and legacy responses, removing the client-side length check to align with current behavior and prevent regressions.

<sup>Written for commit 1dfb6f339c384fb7c107a8043749be490c6ffb74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

