### PR TITLE
fix(auth): name the failing dependency when credential validation is unavailable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { escapeWWWAuthenticateValue } from './www-authenticate';
 import {
   credentialForOutboundRequest,
   copyManagedOAuthApiKey,
+  credentialValidationUnavailable,
   CredentialValidationUnavailableError,
   hasCredential,
   hasManagedOAuthCredential,
@@ -394,10 +395,16 @@ async function introspectToken(
   expectedResource: string
 ): Promise<OAuthIntrospectionResponse> {
   const introspectionSecret = getOAuthIntrospectionSecret();
-  if (!introspectionSecret) throw new CredentialValidationUnavailableError();
+  if (!introspectionSecret)
+    throw credentialValidationUnavailable('introspect_secret_missing');
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 1500);
+  let aborted = false;
+  const timeout = setTimeout(() => {
+    aborted = true;
+    controller.abort();
+  }, 1500);
+  const startedAt = Date.now();
   let response: Response;
   try {
     response = await fetch(getOAuthIntrospectionEndpoint(), {
@@ -414,18 +421,38 @@ async function introspectToken(
       signal: controller.signal,
     });
   } catch {
-    throw new CredentialValidationUnavailableError();
+    throw credentialValidationUnavailable('introspect_fetch_failed', {
+      aborted,
+      elapsedMs: Date.now() - startedAt,
+      resource: expectedResource,
+    });
   } finally {
     clearTimeout(timeout);
   }
-  if (!response.ok) throw new CredentialValidationUnavailableError();
+  const elapsedMs = Date.now() - startedAt;
+  if (!response.ok) {
+    throw credentialValidationUnavailable('introspect_non_2xx', {
+      status: response.status,
+      elapsedMs,
+      resource: expectedResource,
+    });
+  }
   const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
   if (!contentType.includes('application/json')) {
-    throw new CredentialValidationUnavailableError();
+    throw credentialValidationUnavailable('introspect_non_json', {
+      status: response.status,
+      elapsedMs,
+      contentType,
+      resource: expectedResource,
+    });
   }
   const data = (await response.json()) as OAuthIntrospectionResponse;
   if (typeof data.active !== 'boolean') {
-    throw new CredentialValidationUnavailableError();
+    throw credentialValidationUnavailable('introspect_active_not_boolean', {
+      status: response.status,
+      elapsedMs,
+      resource: expectedResource,
+    });
   }
   if (
     data.active &&
@@ -433,7 +460,11 @@ async function introspectToken(
       !isOAuthCredentialPurpose(data.credential_purpose) ||
       !values(data.scope).includes(MCP_GLOBAL_SCOPE))
   ) {
-    throw new CredentialValidationUnavailableError();
+    throw credentialValidationUnavailable('introspect_payload_invalid', {
+      status: response.status,
+      elapsedMs,
+      resource: expectedResource,
+    });
   }
   return data;
 }
@@ -1386,11 +1417,12 @@ function getClient(session?: SessionData): FirecrawlApp {
   const client = createClient('request-scoped-hosted-oauth');
   const axiosInstance = (client as any).http?.instance;
   if (!axiosInstance?.interceptors?.request?.use) {
-    throw new CredentialValidationUnavailableError();
+    throw credentialValidationUnavailable('outbound_interceptor_unavailable');
   }
   axiosInstance.interceptors.request.use((config: any) => {
     const credential = credentialForOutboundRequest(session);
-    if (!credential) throw new CredentialValidationUnavailableError();
+    if (!credential)
+      throw credentialValidationUnavailable('outbound_credential_missing');
     config.headers = {
       ...(config.headers ?? {}),
       Authorization: `Bearer ${credential}`,

--- a/src/session-credential.ts
+++ b/src/session-credential.ts
@@ -13,11 +13,70 @@ export interface CredentialSession {
   [managedOAuthApiKey]?: string;
 }
 
+/**
+ * Why credential validation could not complete. Every value maps 1:1 to a
+ * single throw site so an operator can tell a dependency outage (introspection
+ * 5xx, timeout) apart from a deploy fault (missing secret) without a repro.
+ */
+export type CredentialUnavailableReason =
+  | 'delegation_secret_missing'
+  | 'introspect_secret_missing'
+  | 'introspect_fetch_failed'
+  | 'introspect_non_2xx'
+  | 'introspect_non_json'
+  | 'introspect_active_not_boolean'
+  | 'introspect_payload_invalid'
+  | 'outbound_interceptor_unavailable'
+  | 'outbound_credential_missing';
+
+/** Non-sensitive context for one failure. Never carries tokens or api keys. */
+export type CredentialUnavailableDetail = {
+  /** HTTP status from the introspection endpoint, when there was a response. */
+  status?: number;
+  /** Wall time spent on the introspection request, in ms. */
+  elapsedMs?: number;
+  /** True when the 1500ms AbortController fired rather than the socket failing. */
+  aborted?: boolean;
+  /** Response content-type, when the body was not JSON. */
+  contentType?: string;
+  /** MCP resource URL the token was introspected against. */
+  resource?: string;
+};
+
 export class CredentialValidationUnavailableError extends Error {
-  constructor() {
+  readonly reason: CredentialUnavailableReason;
+  readonly detail: CredentialUnavailableDetail;
+
+  constructor(
+    reason: CredentialUnavailableReason,
+    detail: CredentialUnavailableDetail = {}
+  ) {
+    // The user-facing message is deliberately unchanged and reason-free: it is
+    // asserted by the smoke tests and shown verbatim to MCP clients.
     super('Firecrawl credential validation is temporarily unavailable');
     this.name = 'CredentialValidationUnavailableError';
+    this.reason = reason;
+    this.detail = detail;
   }
+}
+
+/**
+ * Builds the error and emits exactly one structured record for it.
+ *
+ * Every throw site goes through here. Previously all nine were bare `throw new
+ * ...()` with no logging, so a 503 storm left no trace in stdout, in the
+ * request tables, or in the warehouse, and the surviving evidence could not
+ * distinguish an absent secret from an introspection outage.
+ */
+export function credentialValidationUnavailable(
+  reason: CredentialUnavailableReason,
+  detail: CredentialUnavailableDetail = {}
+): CredentialValidationUnavailableError {
+  console.error(
+    '[MCP_CREDENTIAL_UNAVAILABLE]',
+    JSON.stringify({ reason, ...detail })
+  );
+  return new CredentialValidationUnavailableError(reason, detail);
 }
 
 type McpDelegatedCredentialPayload = {
@@ -31,7 +90,7 @@ type McpDelegatedCredentialPayload = {
 
 function delegationSecret(): string {
   const secret = process.env.MCP_DELEGATED_CREDENTIAL_SECRET?.trim();
-  if (!secret) throw new CredentialValidationUnavailableError();
+  if (!secret) throw credentialValidationUnavailable('delegation_secret_missing');
   return secret;
 }
 

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1891,6 +1891,58 @@ test('credential validation outages do not misdirect clients into OAuth', async 
   }
 });
 
+test('credential validation outages name the failing dependency in logs', async (t) => {
+  const backend = await startFakeFirecrawlBackend();
+  t.after(() => backend.close());
+  const unavailableIssuerPort = await getFreePort();
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp-oauth',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_MCP_RESOURCE_URL: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+    FIRECRAWL_OAUTH_ISSUER: `http://127.0.0.1:${unavailableIssuerPort}`,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  await waitForHealth(port, child);
+
+  const response = await fetch(`http://127.0.0.1:${port}/v2/mcp-oauth`, {
+    body: JSON.stringify({ id: 1, jsonrpc: '2.0', method: 'tools/list', params: {} }),
+    headers: {
+      accept: 'application/json, text/event-stream',
+      authorization: 'Bearer fco_account_token',
+      'content-type': 'application/json',
+    },
+    method: 'POST',
+  });
+  assert.equal(response.status, 503);
+
+  const records = stderr
+    .split('\n')
+    .filter((line) => line.includes('[MCP_CREDENTIAL_UNAVAILABLE]'))
+    .map((line) =>
+      JSON.parse(line.slice(line.indexOf('[MCP_CREDENTIAL_UNAVAILABLE]') + 28))
+    );
+  assert.ok(records.length > 0, `no credential telemetry emitted: ${stderr}`);
+
+  // An unreachable issuer is a dependency outage, not a deploy fault. Operators
+  // must be able to tell those apart without reproducing the failure.
+  const record = records[0];
+  assert.equal(record.reason, 'introspect_fetch_failed');
+  assert.equal(typeof record.elapsedMs, 'number');
+  assert.equal(record.resource, 'https://mcp.firecrawl.dev/v2/mcp-oauth');
+
+  // The record explains the outage without carrying the credential that caused it.
+  assert.equal(stderr.includes('fco_account_token'), false, stderr);
+});
+
 test('active introspection with an unknown credential purpose fails closed', async (t) => {
   const accountResource = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
   const backend = await startFakeFirecrawlBackend({


### PR DESCRIPTION
## Why

`Firecrawl credential validation is temporarily unavailable` is a shared bucket, not a cause. `CredentialValidationUnavailableError` is thrown from **nine** sites in `src/index.ts` and `src/session-credential.ts`; only one is the missing `MCP_DELEGATED_CREDENTIAL_SECRET`. The rest are introspection failures — absent introspect secret, fetch throw or the 1500 ms `AbortController` abort, non-2xx, non-JSON content-type, non-boolean `active`, malformed active payload — plus two outbound-client faults.

**All nine were bare `throw new CredentialValidationUnavailableError()` with no logging.** Consequences:

- 3 days of `gcloud logging read` over the `mcp-server` namespace returns **0 rows** for this failure. It is structurally invisible in stdout.
- It is thrown in the FastMCP `authenticate` hook *before* any Core call, so it also produces no row in `requests`, `auth_events`, or any warehouse table. There is no way to count it.
- The user-facing message names *credentials* even when the real fault is an introspection dependency, which sends every investigation to the wrong place.

Because the server runs stateless httpStream, `authenticate()` fires on every POST, so each tool call makes its own uncached, un-retried introspection round-trip against a hard 1500 ms budget. That is why the failure presents as intermittent rather than as an outage — and why it is unattributable without a reason tag.

Four reports over five days (two Pylon tickets, two internal) could not be assigned a cause with the evidence available.

## What

Route every throw through `credentialValidationUnavailable(reason, detail)`, which emits exactly one structured record and returns the error:

```
[MCP_CREDENTIAL_UNAVAILABLE] {"reason":"introspect_non_2xx","status":500,"elapsedMs":247,"resource":"..."}
```

Nine reasons, one per throw site. Introspection failures carry `status`, `elapsedMs`, an `aborted` flag that separates the 1500 ms timeout from a socket failure, `contentType` where relevant, and the resource URL.

`elapsedMs` + `aborted` are the two fields that settle the current open question: a fast 5xx (~250 ms) points at the introspect route rethrowing an unguarded SQLSTATE, while `aborted: true` near 1500 ms points at cold-instance latency. Today those are indistinguishable.

The record carries **no token, no api key, no secret** — asserted by the test.

## Unchanged on purpose

The user-facing message and the 503 shape (no `WWW-Authenticate`) are untouched. They are asserted by the existing smoke tests and shown verbatim to MCP clients; changing them would be a client-visible break and is out of scope here.

## Test

Adds `credential validation outages name the failing dependency in logs`: points the server at an unreachable issuer, asserts the 503 still happens, asserts a record is emitted with `reason: introspect_fetch_failed` and a numeric `elapsedMs`, and asserts the bearer token does not appear in stderr.

`npm test` — **75/75 pass** (74 before). `npm run lint` clean.

## Not in this PR

Two related defects found in the same investigation, deliberately left out to keep this reviewable:

1. `scalable` and `sse` use `readinessProbe: /health` (a static `200 "ok"` with no env check) while only `profile-oauth`/`profile-search` use `/ready`. claude.ai connectors resolve to `/v2/mcp`, served by `scalable` — so the readiness gate does not protect the endpoint that carries that traffic. Fix belongs in `firecrawl-infra`.
2. `!response.ok` treats every non-2xx alike; 5xx should probably be retried once rather than surfaced as a terminal 503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names the failing dependency when credential validation is unavailable and emits a structured log per failure. Previously all failures were unlabeled and unlogged; now each site records a reason without changing the 503 response or message.

- Adds `credentialValidationUnavailable(reason, detail)` that logs one `[MCP_CREDENTIAL_UNAVAILABLE]` record and returns `CredentialValidationUnavailableError`. Introspection paths include `status`, `elapsedMs`, `aborted`, `contentType`, and `resource`. No tokens or API keys are logged.
- Replaces bare throws at nine sites with explicit reasons: `delegation_secret_missing`, `introspect_secret_missing`, `introspect_fetch_failed`, `introspect_non_2xx`, `introspect_non_json`, `introspect_active_not_boolean`, `introspect_payload_invalid`, `outbound_interceptor_unavailable`, `outbound_credential_missing`.
- Adds a smoke test that forces an unreachable issuer, asserts the 503 shape is unchanged, verifies a single log with `reason: "introspect_fetch_failed"` and `elapsedMs`, and confirms no credential leakage.

<sup>Written for commit db3b9075cd1942929293ecd865126dcf188c1c01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

