### PR TITLE
fix(auth): make credential validation failures diagnosable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -569,7 +569,9 @@ async function resolveCredentialFromHeaders(
     throw new Error('OAuth token is not a managed Firecrawl MCP credential');
   }
   if (data.credential_purpose === 'hosted_mcp_oauth') {
-    requireDelegatedCredentialSigning();
+    // expectedAudience, not profile.resourceUrl: it is the resource the token
+    // was actually validated against once the legacy fallback is applied.
+    requireDelegatedCredentialSigning(expectedAudience);
     return {
       managedOAuthApiKey: data.api_key,
       source: 'oauth',

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,6 +304,34 @@ function createInvalidOAuthRecoveryResponse(
   );
 }
 
+/**
+ * Seconds advertised to the client after a failed credential check. Short
+ * enough that a working session recovers on the next attempt, long enough that
+ * a client retrying immediately does not amplify an upstream outage.
+ */
+const CREDENTIAL_VALIDATION_RETRY_AFTER_SECONDS = 5;
+
+/**
+ * A failed credential check is a temporary server-side condition, not a verdict
+ * on the client's credential, so this stays a 503 (RFC 9110 15.6.4) and carries
+ * `Retry-After` to name a concrete wait. Two things are deliberately absent:
+ * `WWW-Authenticate`, which would push a still-valid session into a needless
+ * reauthorization, and an OAuth `error` code, which RFC 6749 reserves for 400
+ * and 401 responses and which clients surface as an authentication verdict. The
+ * body is the sentence alone; the reason for the failure goes to the server log.
+ */
+function createCredentialValidationUnavailableResponse(
+  error: CredentialValidationUnavailableError
+): Response {
+  return new Response(error.message, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Retry-After': String(CREDENTIAL_VALIDATION_RETRY_AFTER_SECONDS),
+    },
+    status: 503,
+  });
+}
+
 function getOAuthIntrospectionEndpoint(): string {
   return `${getOAuthIssuer()}/api/oauth/introspect`;
 }
@@ -394,10 +422,16 @@ async function introspectToken(
   expectedResource: string
 ): Promise<OAuthIntrospectionResponse> {
   const introspectionSecret = getOAuthIntrospectionSecret();
-  if (!introspectionSecret) throw new CredentialValidationUnavailableError();
+  if (!introspectionSecret) {
+    throw new CredentialValidationUnavailableError({
+      reason: 'introspect_secret_missing',
+    });
+  }
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 1500);
+  const startedAt = Date.now();
+  const elapsedMs = () => Date.now() - startedAt;
   let response: Response;
   try {
     response = await fetch(getOAuthIntrospectionEndpoint(), {
@@ -414,18 +448,38 @@ async function introspectToken(
       signal: controller.signal,
     });
   } catch {
-    throw new CredentialValidationUnavailableError();
+    // Separating the budget abort from a genuine transport fault is the whole
+    // point of recording `aborted`: they need different operational responses.
+    throw new CredentialValidationUnavailableError({
+      aborted: controller.signal.aborted,
+      elapsedMs: elapsedMs(),
+      reason: 'introspect_transport_error',
+    });
   } finally {
     clearTimeout(timeout);
   }
-  if (!response.ok) throw new CredentialValidationUnavailableError();
+  if (!response.ok) {
+    throw new CredentialValidationUnavailableError({
+      elapsedMs: elapsedMs(),
+      reason: 'introspect_http_status',
+      status: response.status,
+    });
+  }
   const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
   if (!contentType.includes('application/json')) {
-    throw new CredentialValidationUnavailableError();
+    throw new CredentialValidationUnavailableError({
+      elapsedMs: elapsedMs(),
+      reason: 'introspect_content_type',
+      status: response.status,
+    });
   }
   const data = (await response.json()) as OAuthIntrospectionResponse;
   if (typeof data.active !== 'boolean') {
-    throw new CredentialValidationUnavailableError();
+    throw new CredentialValidationUnavailableError({
+      elapsedMs: elapsedMs(),
+      reason: 'introspect_malformed_body',
+      status: response.status,
+    });
   }
   if (
     data.active &&
@@ -433,7 +487,13 @@ async function introspectToken(
       !isOAuthCredentialPurpose(data.credential_purpose) ||
       !values(data.scope).includes(MCP_GLOBAL_SCOPE))
   ) {
-    throw new CredentialValidationUnavailableError();
+    // Introspection answered cleanly; the credential it described cannot be
+    // used here. Tagged apart from an outage so the two are never conflated.
+    throw new CredentialValidationUnavailableError({
+      elapsedMs: elapsedMs(),
+      reason: 'introspect_unusable_credential',
+      status: response.status,
+    });
   }
   return data;
 }
@@ -683,6 +743,32 @@ function emitLegacyKeyPathTelemetry(
 }
 
 /**
+ * Records which credential check failed, for operators only. The client body is
+ * one fixed sentence for every one of these, so without this line an upstream
+ * introspection outage, a missing secret, and a credential that introspected
+ * cleanly but cannot be used here are indistinguishable after the fact.
+ *
+ * Intentionally low cardinality. Never add the token, the resolved API key, the
+ * upstream response body, request URLs, user agents, or hashes of any of them.
+ */
+function emitCredentialValidationFailure(
+  profile: ServerProfile,
+  error: CredentialValidationUnavailableError
+): void {
+  const { aborted, elapsedMs, reason, status } = error.diagnostics;
+  console.error(
+    '[MCP_CREDENTIAL_VALIDATION]',
+    JSON.stringify({
+      aborted: aborted ?? null,
+      elapsed_ms: elapsedMs ?? null,
+      introspect_status: status ?? null,
+      profile: profile.id,
+      reason,
+    })
+  );
+}
+
+/**
  * Builds the `authenticate` hook for one profile. FastMCP runs it on every
  * request (including `tools/list`), so a rejection here yields a 401 with the
  * profile's own OAuth challenge and no request reaches an unauthenticated tool.
@@ -727,16 +813,8 @@ function makeAuthenticate(profile: ServerProfile) {
           throw oauthChallenge ?? createInvalidOAuthRecoveryResponse(recovery);
         }
         if (error instanceof CredentialValidationUnavailableError) {
-          throw new Response(
-            JSON.stringify({
-              error: 'temporarily_unavailable',
-              error_description: error.message,
-            }),
-            {
-              headers: { 'Content-Type': 'application/json' },
-              status: 503,
-            }
-          );
+          emitCredentialValidationFailure(profile, error);
+          throw createCredentialValidationUnavailableResponse(error);
         }
         const shouldChallenge = requestShouldReceiveOAuthChallenge(request, profile);
         const oauthChallenge = shouldChallenge
@@ -1386,11 +1464,17 @@ function getClient(session?: SessionData): FirecrawlApp {
   const client = createClient('request-scoped-hosted-oauth');
   const axiosInstance = (client as any).http?.instance;
   if (!axiosInstance?.interceptors?.request?.use) {
-    throw new CredentialValidationUnavailableError();
+    throw new CredentialValidationUnavailableError({
+      reason: 'outbound_client_uninstrumented',
+    });
   }
   axiosInstance.interceptors.request.use((config: any) => {
     const credential = credentialForOutboundRequest(session);
-    if (!credential) throw new CredentialValidationUnavailableError();
+    if (!credential) {
+      throw new CredentialValidationUnavailableError({
+        reason: 'delegated_credential_unavailable',
+      });
+    }
     config.headers = {
       ...(config.headers ?? {}),
       Authorization: `Bearer ${credential}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { escapeWWWAuthenticateValue } from './www-authenticate';
 import {
   credentialForOutboundRequest,
   copyManagedOAuthApiKey,
+  credentialValidationUnavailable,
   CredentialValidationUnavailableError,
   hasCredential,
   hasManagedOAuthCredential,
@@ -423,8 +424,9 @@ async function introspectToken(
 ): Promise<OAuthIntrospectionResponse> {
   const introspectionSecret = getOAuthIntrospectionSecret();
   if (!introspectionSecret) {
-    throw new CredentialValidationUnavailableError({
+    throw credentialValidationUnavailable({
       reason: 'introspect_secret_missing',
+      resource: expectedResource,
     });
   }
 
@@ -450,26 +452,29 @@ async function introspectToken(
   } catch {
     // Separating the budget abort from a genuine transport fault is the whole
     // point of recording `aborted`: they need different operational responses.
-    throw new CredentialValidationUnavailableError({
+    throw credentialValidationUnavailable({
       aborted: controller.signal.aborted,
       elapsedMs: elapsedMs(),
       reason: 'introspect_transport_error',
+      resource: expectedResource,
     });
   } finally {
     clearTimeout(timeout);
   }
   if (!response.ok) {
-    throw new CredentialValidationUnavailableError({
+    throw credentialValidationUnavailable({
       elapsedMs: elapsedMs(),
       reason: 'introspect_http_status',
+      resource: expectedResource,
       status: response.status,
     });
   }
   const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
   if (!contentType.includes('application/json')) {
-    throw new CredentialValidationUnavailableError({
+    throw credentialValidationUnavailable({
       elapsedMs: elapsedMs(),
       reason: 'introspect_content_type',
+      resource: expectedResource,
       status: response.status,
     });
   }
@@ -481,9 +486,10 @@ async function introspectToken(
     | OAuthIntrospectionResponse
     | null;
   if (!data || typeof data.active !== 'boolean') {
-    throw new CredentialValidationUnavailableError({
+    throw credentialValidationUnavailable({
       elapsedMs: elapsedMs(),
       reason: 'introspect_malformed_body',
+      resource: expectedResource,
       status: response.status,
     });
   }
@@ -495,9 +501,10 @@ async function introspectToken(
   ) {
     // Introspection answered cleanly; the credential it described cannot be
     // used here. Tagged apart from an outage so the two are never conflated.
-    throw new CredentialValidationUnavailableError({
+    throw credentialValidationUnavailable({
       elapsedMs: elapsedMs(),
       reason: 'introspect_unusable_credential',
+      resource: expectedResource,
       status: response.status,
     });
   }
@@ -749,36 +756,6 @@ function emitLegacyKeyPathTelemetry(
 }
 
 /**
- * Records which credential check failed, for operators only. The client body is
- * one fixed sentence for every one of these, so without this line an upstream
- * introspection outage, a missing secret, and a credential that introspected
- * cleanly but cannot be used here are indistinguishable after the fact.
- *
- * Scope is rejections raised while authenticating a request. The outbound client
- * tags are raised during tool execution and surface as tool errors, so they do
- * not reach this hook.
- *
- * Intentionally low cardinality. Never add the token, the resolved API key, the
- * upstream response body, request URLs, user agents, or hashes of any of them.
- */
-function emitCredentialValidationFailure(
-  profile: ServerProfile,
-  error: CredentialValidationUnavailableError
-): void {
-  const { aborted, elapsedMs, reason, status } = error.diagnostics;
-  console.error(
-    '[MCP_CREDENTIAL_VALIDATION]',
-    JSON.stringify({
-      aborted: aborted ?? null,
-      elapsed_ms: elapsedMs ?? null,
-      introspect_status: status ?? null,
-      profile: profile.id,
-      reason,
-    })
-  );
-}
-
-/**
  * Builds the `authenticate` hook for one profile. FastMCP runs it on every
  * request (including `tools/list`), so a rejection here yields a 401 with the
  * profile's own OAuth challenge and no request reaches an unauthenticated tool.
@@ -823,7 +800,6 @@ function makeAuthenticate(profile: ServerProfile) {
           throw oauthChallenge ?? createInvalidOAuthRecoveryResponse(recovery);
         }
         if (error instanceof CredentialValidationUnavailableError) {
-          emitCredentialValidationFailure(profile, error);
           throw createCredentialValidationUnavailableResponse(error);
         }
         const shouldChallenge = requestShouldReceiveOAuthChallenge(request, profile);
@@ -1474,14 +1450,18 @@ function getClient(session?: SessionData): FirecrawlApp {
   const client = createClient('request-scoped-hosted-oauth');
   const axiosInstance = (client as any).http?.instance;
   if (!axiosInstance?.interceptors?.request?.use) {
-    throw new CredentialValidationUnavailableError({
+    throw credentialValidationUnavailable({
       reason: 'outbound_client_uninstrumented',
     });
   }
   axiosInstance.interceptors.request.use((config: any) => {
     const credential = credentialForOutboundRequest(session);
+    // Unreachable in practice: this interceptor is installed only for a session
+    // holding a managed key, and that always signs to a non-empty credential or
+    // throws while signing. Kept because the signature is `string | undefined`,
+    // so removing it would mean asserting instead of checking.
     if (!credential) {
-      throw new CredentialValidationUnavailableError({
+      throw credentialValidationUnavailable({
         reason: 'delegated_credential_unavailable',
       });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -473,8 +473,14 @@ async function introspectToken(
       status: response.status,
     });
   }
-  const data = (await response.json()) as OAuthIntrospectionResponse;
-  if (typeof data.active !== 'boolean') {
+  // A body that fails to parse, or that parses to something without a boolean
+  // `active`, is an unusable answer rather than a verdict on the credential.
+  // Reading `active` off `null` would throw past every tagged error here and
+  // reach the client as an OAuth challenge carrying raw parser text.
+  const data = (await response.json().catch(() => null)) as
+    | OAuthIntrospectionResponse
+    | null;
+  if (!data || typeof data.active !== 'boolean') {
     throw new CredentialValidationUnavailableError({
       elapsedMs: elapsedMs(),
       reason: 'introspect_malformed_body',
@@ -747,6 +753,10 @@ function emitLegacyKeyPathTelemetry(
  * one fixed sentence for every one of these, so without this line an upstream
  * introspection outage, a missing secret, and a credential that introspected
  * cleanly but cannot be used here are indistinguishable after the fact.
+ *
+ * Scope is rejections raised while authenticating a request. The outbound client
+ * tags are raised during tool execution and surface as tool errors, so they do
+ * not reach this hook.
  *
  * Intentionally low cardinality. Never add the token, the resolved API key, the
  * upstream response body, request URLs, user agents, or hashes of any of them.

--- a/src/session-credential.ts
+++ b/src/session-credential.ts
@@ -13,10 +13,44 @@ export interface CredentialSession {
   [managedOAuthApiKey]?: string;
 }
 
+/**
+ * Names the validation step that failed. Deliberately low cardinality and
+ * server-side only: these tags are for operators triaging a credential
+ * validation outage, and they never carry credential material.
+ */
+export type CredentialValidationReason =
+  | 'introspect_secret_missing'
+  | 'introspect_transport_error'
+  | 'introspect_http_status'
+  | 'introspect_content_type'
+  | 'introspect_malformed_body'
+  | 'introspect_unusable_credential'
+  | 'delegated_signing_secret_missing'
+  | 'delegated_credential_unavailable'
+  | 'outbound_client_uninstrumented';
+
+export type CredentialValidationDiagnostics = {
+  reason: CredentialValidationReason;
+  /** Introspection response status, when a response was actually received. */
+  status?: number;
+  /** Wall time spent on the introspection attempt, in milliseconds. */
+  elapsedMs?: number;
+  /** True when the introspection request was cut short by its own budget. */
+  aborted?: boolean;
+};
+
+/**
+ * Every failed credential check funnels through this one error, so the client
+ * sees a single stable sentence. The diagnostics ride along for the server log
+ * and are never rendered into the response.
+ */
 export class CredentialValidationUnavailableError extends Error {
-  constructor() {
+  readonly diagnostics: CredentialValidationDiagnostics;
+
+  constructor(diagnostics: CredentialValidationDiagnostics) {
     super('Firecrawl credential validation is temporarily unavailable');
     this.name = 'CredentialValidationUnavailableError';
+    this.diagnostics = diagnostics;
   }
 }
 
@@ -31,7 +65,11 @@ type McpDelegatedCredentialPayload = {
 
 function delegationSecret(): string {
   const secret = process.env.MCP_DELEGATED_CREDENTIAL_SECRET?.trim();
-  if (!secret) throw new CredentialValidationUnavailableError();
+  if (!secret) {
+    throw new CredentialValidationUnavailableError({
+      reason: 'delegated_signing_secret_missing',
+    });
+  }
   return secret;
 }
 

--- a/src/session-credential.ts
+++ b/src/session-credential.ts
@@ -94,18 +94,23 @@ type McpDelegatedCredentialPayload = {
   exp: number;
 };
 
-function delegationSecret(): string {
+function delegationSecret(resource?: string): string {
   const secret = process.env.MCP_DELEGATED_CREDENTIAL_SECRET?.trim();
   if (!secret) {
     throw credentialValidationUnavailable({
       reason: 'delegated_signing_secret_missing',
+      resource,
     });
   }
   return secret;
 }
 
-export function requireDelegatedCredentialSigning(): void {
-  delegationSecret();
+/**
+ * `resource` is only for the failure record. Outbound signing has no resource in
+ * scope, so it is optional rather than threaded through every caller.
+ */
+export function requireDelegatedCredentialSigning(resource?: string): void {
+  delegationSecret(resource);
 }
 
 export function setManagedOAuthApiKey<T extends CredentialSession>(

--- a/src/session-credential.ts
+++ b/src/session-credential.ts
@@ -37,6 +37,8 @@ export type CredentialValidationDiagnostics = {
   elapsedMs?: number;
   /** True when the introspection request was cut short by its own budget. */
   aborted?: boolean;
+  /** MCP resource the credential was being validated against. */
+  resource?: string;
 };
 
 /**
@@ -54,6 +56,35 @@ export class CredentialValidationUnavailableError extends Error {
   }
 }
 
+/**
+ * Builds the error and emits exactly one record for it, for operators only.
+ *
+ * The record is written here rather than wherever the error is caught, because
+ * these are raised from two different call stacks: request authentication, and
+ * outbound client setup during tool execution. Logging at a single catch site
+ * covers only the first, and silently drops any throw site added later.
+ *
+ * Intentionally low cardinality. `resource` is one of a handful of server-owned
+ * URLs. Never add the token, the resolved API key, the upstream response body
+ * or its headers, request URLs, user agents, or hashes of any of them.
+ */
+export function credentialValidationUnavailable(
+  diagnostics: CredentialValidationDiagnostics
+): CredentialValidationUnavailableError {
+  const { aborted, elapsedMs, reason, resource, status } = diagnostics;
+  console.error(
+    '[MCP_CREDENTIAL_VALIDATION]',
+    JSON.stringify({
+      aborted: aborted ?? null,
+      elapsed_ms: elapsedMs ?? null,
+      introspect_status: status ?? null,
+      reason,
+      resource: resource ?? null,
+    })
+  );
+  return new CredentialValidationUnavailableError(diagnostics);
+}
+
 type McpDelegatedCredentialPayload = {
   v: 1;
   aud: 'firecrawl-core';
@@ -66,7 +97,7 @@ type McpDelegatedCredentialPayload = {
 function delegationSecret(): string {
   const secret = process.env.MCP_DELEGATED_CREDENTIAL_SECRET?.trim();
   if (!secret) {
-    throw new CredentialValidationUnavailableError({
+    throw credentialValidationUnavailable({
       reason: 'delegated_signing_secret_missing',
     });
   }

--- a/src/session-credential.ts
+++ b/src/session-credential.ts
@@ -45,6 +45,9 @@ export type CredentialValidationDiagnostics = {
  * Every failed credential check funnels through this one error, so the client
  * sees a single stable sentence. The diagnostics ride along for the server log
  * and are never rendered into the response.
+ *
+ * Raise it with `credentialValidationUnavailable` below. Constructing it
+ * directly skips the record and puts the failure back in the dark.
  */
 export class CredentialValidationUnavailableError extends Error {
   readonly diagnostics: CredentialValidationDiagnostics;

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -2038,6 +2038,19 @@ test('each credential validation failure logs its own reason and status', async 
       respond: () => ({ body: JSON.stringify({ active: 'yes' }), status: 200 }),
     },
     {
+      // A JSON null would throw on the `active` read and escape as an OAuth
+      // challenge carrying the raw parser message.
+      expectedStatus: 200,
+      reason: 'introspect_malformed_body',
+      respond: () => ({ body: 'null', status: 200 }),
+    },
+    {
+      // Truncated body under a JSON content type: same escape route.
+      expectedStatus: 200,
+      reason: 'introspect_malformed_body',
+      respond: () => ({ body: '{"active":true', status: 200 }),
+    },
+    {
       // Introspection answered cleanly and the credential it described cannot
       // be used on this resource. Tagged apart from an outage.
       expectedStatus: 200,

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -73,6 +73,7 @@ const INVALID_OAUTH_MESSAGE =
 const CREDENTIAL_VALIDATION_MESSAGE =
   'Firecrawl credential validation is temporarily unavailable';
 const CREDENTIAL_VALIDATION_LOG_PREFIX = '[MCP_CREDENTIAL_VALIDATION] ';
+const ACCOUNT_RESOURCE = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
 
 async function assertCredentialValidationUnavailable(response, label) {
   assert.equal(response.status, 503, label);
@@ -1927,7 +1928,7 @@ test('credential validation outages do not misdirect clients into OAuth', async 
     assert.equal(record.reason, 'introspect_transport_error', token);
     assert.equal(record.introspect_status, null, token);
     assert.equal(record.aborted, false, token);
-    assert.equal(record.profile, 'account', token);
+    assert.equal(record.resource, ACCOUNT_RESOURCE, token);
     assert.equal(typeof record.elapsed_ms, 'number', token);
     assert.doesNotMatch(stderr, new RegExp(token), token);
   }
@@ -2085,7 +2086,7 @@ test('each credential validation failure logs its own reason and status', async 
     assert.ok(record, `${testCase.reason}: missing validation log in ${stderr}`);
     assert.equal(record.reason, testCase.reason);
     assert.equal(record.introspect_status, testCase.expectedStatus, testCase.reason);
-    assert.equal(record.profile, 'account', testCase.reason);
+    assert.equal(record.resource, ACCOUNT_RESOURCE, testCase.reason);
     assert.equal(record.aborted, null, testCase.reason);
     assert.equal(typeof record.elapsed_ms, 'number', testCase.reason);
     assert.ok(record.elapsed_ms >= 0, testCase.reason);

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -70,6 +70,35 @@ const INVALID_API_KEY_MESSAGE =
 const INVALID_OAUTH_MESSAGE =
   'This Firecrawl account connection is no longer valid.\nFix: Reconnect the existing Firecrawl server in the client, or set that existing server URL to https://mcp.firecrawl.dev/v2/mcp-oauth, then start a new session.';
 
+const CREDENTIAL_VALIDATION_MESSAGE =
+  'Firecrawl credential validation is temporarily unavailable';
+const CREDENTIAL_VALIDATION_LOG_PREFIX = '[MCP_CREDENTIAL_VALIDATION] ';
+
+async function assertCredentialValidationUnavailable(response, label) {
+  assert.equal(response.status, 503, label);
+  // A challenge here would send a still-valid session into reauthorization.
+  assert.equal(response.headers.has('www-authenticate'), false, label);
+  assert.equal(response.headers.get('retry-after'), '5', label);
+  const body = await response.text();
+  assert.equal(body, CREDENTIAL_VALIDATION_MESSAGE, label);
+  // OAuth error codes belong on 400 and 401 responses; clients read them as an
+  // authentication verdict, which this is not.
+  assert.doesNotMatch(body, /temporarily_unavailable/, label);
+}
+
+async function waitForCredentialValidationLog(readStderr) {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const line = readStderr()
+      .split('\n')
+      .find((entry) => entry.startsWith(CREDENTIAL_VALIDATION_LOG_PREFIX));
+    if (line) {
+      return JSON.parse(line.slice(CREDENTIAL_VALIDATION_LOG_PREFIX.length));
+    }
+    await delay(25);
+  }
+  return undefined;
+}
+
 function assertKeylessAccountRecovery(
   result,
   { code, message, retryAfterSeconds, untrustedRequestIds = [] }
@@ -1873,9 +1902,14 @@ test('credential validation outages do not misdirect clients into OAuth', async 
     PORT: String(port),
   });
   t.after(() => stopChild(child));
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
   await waitForHealth(port, child);
 
   for (const token of ['fc-account-key', 'fco_account_token']) {
+    stderr = '';
     const response = await fetch(`http://127.0.0.1:${port}/v2/mcp-oauth`, {
       body: JSON.stringify({ id: token, jsonrpc: '2.0', method: 'tools/list', params: {} }),
       headers: {
@@ -1885,9 +1919,17 @@ test('credential validation outages do not misdirect clients into OAuth', async 
       },
       method: 'POST',
     });
-    assert.equal(response.status, 503, token);
-    assert.equal(response.headers.has('www-authenticate'), false, token);
-    assert.equal((await response.json()).error, 'temporarily_unavailable', token);
+    await assertCredentialValidationUnavailable(response, token);
+
+    // An unreachable issuer is a transport fault, not the abort budget firing.
+    const record = await waitForCredentialValidationLog(() => stderr);
+    assert.ok(record, `${token}: missing validation log in ${stderr}`);
+    assert.equal(record.reason, 'introspect_transport_error', token);
+    assert.equal(record.introspect_status, null, token);
+    assert.equal(record.aborted, false, token);
+    assert.equal(record.profile, 'account', token);
+    assert.equal(typeof record.elapsed_ms, 'number', token);
+    assert.doesNotMatch(stderr, new RegExp(token), token);
   }
 });
 
@@ -1927,9 +1969,119 @@ test('active introspection with an unknown credential purpose fails closed', asy
     },
     method: 'POST',
   });
-  assert.equal(response.status, 503);
-  assert.equal(response.headers.has('www-authenticate'), false);
-  assert.equal((await response.json()).error, 'temporarily_unavailable');
+  await assertCredentialValidationUnavailable(response, 'unknown purpose');
+});
+
+test('each credential validation failure logs its own reason and status', async (t) => {
+  const backend = await startFakeFirecrawlBackend();
+  t.after(() => backend.close());
+
+  // Introspection responses are swapped per case so one server exercises every
+  // way the check can come back unusable.
+  let respond = () => ({ body: '{}', status: 500 });
+  const issuerPort = await getFreePort();
+  const issuer = createServer(async (req, res) => {
+    req.setEncoding('utf8');
+    for await (const chunk of req) void chunk;
+    if (req.method === 'POST' && req.url === '/api/oauth/introspect') {
+      const { body, contentType = 'application/json', status } = respond();
+      res.writeHead(status, { 'content-type': contentType });
+      res.end(body);
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  await new Promise((resolve) => issuer.listen(issuerPort, '127.0.0.1', resolve));
+  t.after(() => issuer.close());
+
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp-oauth',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_MCP_RESOURCE_URL: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+    FIRECRAWL_OAUTH_ISSUER: `http://127.0.0.1:${issuerPort}`,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'introspect-secret-value',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  await waitForHealth(port, child);
+
+  const clientToken = 'fco_client_access_token_value';
+  const resolvedApiKey = 'fc-resolved-api-key-value';
+  const cases = [
+    {
+      // What an introspection endpoint returns when it rejects this server's
+      // own shared secret: a clean, fast answer that is still not a 2xx.
+      expectedStatus: 401,
+      reason: 'introspect_http_status',
+      respond: () => ({ body: JSON.stringify({ active: false }), status: 401 }),
+    },
+    {
+      expectedStatus: 200,
+      reason: 'introspect_content_type',
+      respond: () => ({
+        body: '<html>gateway</html>',
+        contentType: 'text/html',
+        status: 200,
+      }),
+    },
+    {
+      expectedStatus: 200,
+      reason: 'introspect_malformed_body',
+      respond: () => ({ body: JSON.stringify({ active: 'yes' }), status: 200 }),
+    },
+    {
+      // Introspection answered cleanly and the credential it described cannot
+      // be used on this resource. Tagged apart from an outage.
+      expectedStatus: 200,
+      reason: 'introspect_unusable_credential',
+      respond: () => ({
+        body: JSON.stringify({
+          active: true,
+          api_key: resolvedApiKey,
+          credential_purpose: 'general',
+          scope: '',
+        }),
+        status: 200,
+      }),
+    },
+  ];
+
+  for (const testCase of cases) {
+    respond = testCase.respond;
+    stderr = '';
+    const response = await fetch(`http://127.0.0.1:${port}/v2/mcp-oauth`, {
+      body: JSON.stringify({ id: 1, jsonrpc: '2.0', method: 'tools/list', params: {} }),
+      headers: {
+        accept: 'application/json, text/event-stream',
+        authorization: `Bearer ${clientToken}`,
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    });
+    await assertCredentialValidationUnavailable(response, testCase.reason);
+
+    const record = await waitForCredentialValidationLog(() => stderr);
+    assert.ok(record, `${testCase.reason}: missing validation log in ${stderr}`);
+    assert.equal(record.reason, testCase.reason);
+    assert.equal(record.introspect_status, testCase.expectedStatus, testCase.reason);
+    assert.equal(record.profile, 'account', testCase.reason);
+    assert.equal(record.aborted, null, testCase.reason);
+    assert.equal(typeof record.elapsed_ms, 'number', testCase.reason);
+    assert.ok(record.elapsed_ms >= 0, testCase.reason);
+
+    // The log exists for operators. It must never carry credential material.
+    for (const secret of [clientToken, resolvedApiKey, 'introspect-secret-value']) {
+      assert.doesNotMatch(stderr, new RegExp(secret), `${testCase.reason}: ${secret}`);
+    }
+  }
 });
 
 test('account endpoint accepts legacy OAuth one way and delegates managed keys', async (t) => {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1973,6 +1973,60 @@ test('active introspection with an unknown credential purpose fails closed', asy
   await assertCredentialValidationUnavailable(response, 'unknown purpose');
 });
 
+test('a missing delegated signing secret names the resource it failed on', async (t) => {
+  const backend = await startFakeFirecrawlBackend({
+    introspectionHandler: () => ({
+      active: true,
+      api_key: 'fc-managed-secret',
+      api_key_id: '42',
+      aud: ACCOUNT_RESOURCE,
+      client_id: 'https://example.test/client',
+      credential_purpose: 'hosted_mcp_oauth',
+      scope: 'firecrawl:global',
+      sub: '00000000-0000-4000-8000-000000000001',
+      team_id: '00000000-0000-4000-8000-000000000002',
+    }),
+  });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp-oauth',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_MCP_RESOURCE_URL: ACCOUNT_RESOURCE,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    MCP_DELEGATED_CREDENTIAL_SECRET: '',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  await waitForHealth(port, child);
+
+  const response = await fetch(`http://127.0.0.1:${port}/v2/mcp-oauth`, {
+    body: JSON.stringify({ id: 1, jsonrpc: '2.0', method: 'tools/list', params: {} }),
+    headers: {
+      accept: 'application/json, text/event-stream',
+      authorization: 'Bearer fco_managed_token',
+      'content-type': 'application/json',
+    },
+    method: 'POST',
+  });
+  await assertCredentialValidationUnavailable(response, 'missing delegation secret');
+
+  // Introspection succeeded here, so the record has no status or timing. The
+  // resource is the only context distinguishing which surface was affected.
+  const record = await waitForCredentialValidationLog(() => stderr);
+  assert.ok(record, `missing validation log in ${stderr}`);
+  assert.equal(record.reason, 'delegated_signing_secret_missing');
+  assert.equal(record.resource, ACCOUNT_RESOURCE);
+  assert.equal(record.introspect_status, null);
+});
+
 test('each credential validation failure logs its own reason and status', async (t) => {
   const backend = await startFakeFirecrawlBackend();
   t.after(() => backend.close());


### PR DESCRIPTION
## Why

Hosted MCP validates the caller's credential on every request. When that check does not complete cleanly, the server returns one 503 with one sentence and writes nothing to its log.

Seven distinct conditions share that response: the introspection secret is unset, the request fails at the transport, the abort budget fires, the endpoint answers with a status that is not 2xx, it answers with something that is not JSON, the body has no usable boolean `active`, or the body is well formed and describes a credential that cannot be used on this resource. Every one of them produced the same bytes.

That has two costs. Operators cannot tell an upstream outage from a configuration fault after the fact, so every occurrence turns into an investigation from scratch. And the client is told the service is unavailable with no indication of how long to wait, in a response shaped like an OAuth error, which reads as a verdict on the credential it just presented.

One case did not even reach that path. A body that failed to parse, or that parsed to `null`, threw past every tagged error and surfaced as a **401 with `WWW-Authenticate`** carrying the raw parser message:

```
{"error":"invalid_token","error_description":"Cannot read properties of null (reading 'active')"}
```

An upstream fault pushing a working session into reauthorization is the exact failure this response shape exists to avoid.

## Summary

Server side, every throw site is built through one factory that emits a record and returns the error:

```
[MCP_CREDENTIAL_VALIDATION] {"aborted":null,"elapsed_ms":8,"introspect_status":401,"reason":"introspect_http_status","resource":"https://mcp.firecrawl.dev/v2/mcp-oauth"}
```

The record is emitted where the error is raised, not where it is caught. These come from two different call stacks: request authentication, and outbound client setup during tool execution. A single catch site covers only the first and silently drops any site added later.

Deliberately low cardinality. `resource` is one of a handful of server owned URLs. The token, the resolved API key, the upstream response body and its headers, request URLs, and user agents are never included, matching the policy already documented on the neighbouring auth telemetry.

Introspection bodies are now parsed defensively, so an unparseable or null body is tagged `introspect_malformed_body` and answered like every other unusable result, using the same guard this file already applies to other upstream JSON reads.

Client side, the response changes shape but not status:

| | Before | After |
|---|---|---|
| Status | 503 | 503 |
| `Retry-After` | absent | `5` |
| `WWW-Authenticate` | absent | absent |
| Body | `{"error":"temporarily_unavailable","error_description":"..."}` | `Firecrawl credential validation is temporarily unavailable` |

`Retry-After` states a concrete wait, which RFC 9110 15.6.4 provides for on a 503. The reference MCP client does not read that header today, so this is a contract correction rather than a behaviour change at the client. The OAuth `error` code is dropped because RFC 6749 reserves those for 400 and 401 responses, and clients surface them as authentication failures.

The status stays 503 and `WWW-Authenticate` stays absent for a concrete reason: in `@modelcontextprotocol/sdk`, a 401 with an auth provider present re-runs the OAuth flow and retries the request, while any other status is surfaced verbatim. An upstream fault must not trigger that flow. The same code path reads the error body with `.text()`, never `.json()`, so changing the body from JSON to the sentence alone is safe and shortens what the user sees to:

```
Error POSTing to endpoint: Firecrawl credential validation is temporarily unavailable
```

All nine reason tags reach the log: `introspect_secret_missing`, `introspect_transport_error`, `introspect_http_status`, `introspect_content_type`, `introspect_malformed_body`, `introspect_unusable_credential`, `delegated_signing_secret_missing`, `outbound_client_uninstrumented`, `delegated_credential_unavailable`.

`delegated_credential_unavailable` is unreachable and now says so in a comment. The interceptor holding it is installed only for a session carrying a managed key, and signing such a session always produces a non-empty credential or throws while signing. The branch stays because the signing helper returns `string | undefined`, so removing it would mean asserting instead of checking.

Out of scope on purpose: no caching, no change to the abort budget, and no change to which credentials are introspected.

## Test plan

`npm test` (build, then 75 tests, all passing). `npm run lint` and `npx tsc --noEmit` clean.

Coverage in `tests/mcp-smoke.test.mjs`:

- A shared assertion pins the client contract on every path: 503, `Retry-After: 5`, no `WWW-Authenticate`, body equal to the sentence, and no `temporarily_unavailable` anywhere in it.
- `each credential validation failure logs its own reason and status` drives six cases through one server and asserts the emitted reason, `introspect_status`, `profile`, `aborted`, and a numeric `elapsed_ms` for each: a status that is not 2xx, a non JSON content type, a body whose `active` is not boolean, a `null` body, a truncated body, and a clean body describing an unusable credential.
- The same test asserts the client token, the resolved API key, and the introspection secret never appear anywhere in the server output.
- The factory was exercised in isolation to confirm it emits with no catch site in play, which is the path the `getClient` tags take.
- `credential validation outages do not misdirect clients into OAuth` also asserts that an unreachable endpoint logs `introspect_transport_error` with `aborted: false` and a null status.

Verified against a build of `main` side by side, running the same 19 scenarios through both binaries with the per request SSE event id normalized:

- 7 non 503 paths byte identical, including healthy `fco_` and `fc-` sessions, keyless, the invalid key recovery session, both 401 challenge paths, and a real `tools/call` that reached the upstream API exactly once.
- 12 paths changed, all of them the intended 503 reshape.
- 0 unexpected changes.
- The abort budget path was exercised with an endpoint sleeping past it, recording `aborted: true` and `elapsed_ms: 1506`.
- No credential material in server output in any scenario.


