### PR TITLE
fix(developer): omit duplicate URLs and empty separators

### DIFF
--- a/src/developer.ts
+++ b/src/developer.ts
@@ -60,9 +60,10 @@ function fmtDeveloper(
       const kind = r.id?.split(':', 1)[0];
       const kindLabel = kind ? ` (${kind})` : '';
       const lines = [`## [${id}]${kindLabel} ${r.title ?? '(untitled)'}`];
-      if (r.url) lines.push(r.url);
+      if (r.url && !id.endsWith(`:${r.url}`) && id !== r.url) lines.push(r.url);
       const body = (r.passages ?? [])
         .map((p) => p.text ?? '')
+        .filter((passage) => passage.trim().length > 0)
         .join('\n---\n')
         .trim();
       // Passages are server-shaped (search-side budget is always on); no

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -242,6 +242,23 @@ async function startFakeDeveloperApi() {
               title: 'Developer fixture',
               url: 'https://example.com/developer',
             },
+            {
+              id: 'web:https://example.com/answer',
+              passages: [
+                { text: '' },
+                { text: ' ' },
+                { text: 'The answer.' },
+                {},
+              ],
+              title: 'Developer answer',
+              url: 'https://example.com/answer',
+            },
+            {
+              id: 'web:https://example.com/base/child',
+              passages: [{ text: 'The base answer.' }],
+              title: 'Developer base answer',
+              url: 'https://example.com/base',
+            },
           ],
           success: true,
         })
@@ -932,6 +949,18 @@ test('developer search serves server-shaped passages uncapped', async (t) => {
   });
   assert.notEqual(serverBudgeted.isError, true);
   assert.ok(serverBudgeted.content[0].text.includes(fakeApi.passage));
+  assert.equal(
+    serverBudgeted.content[0].text.match(/https:\/\/example\.com\/answer/g)
+      ?.length,
+    1
+  );
+  assert.ok(serverBudgeted.content[0].text.includes('\nThe answer.'));
+  assert.equal(serverBudgeted.content[0].text.includes('\n---\n'), false);
+  assert.ok(
+    serverBudgeted.content[0].text.includes(
+      '## [web:https://example.com/base/child] (web) Developer base answer\nhttps://example.com/base\n'
+    )
+  );
 
   // No client-side cap in any case: even a response without
   // passage_budget_applied (older server) serves the passage whole.


### PR DESCRIPTION
## Summary

- omit the bare URL when the result ID already contains that exact URL
- skip separators for empty or whitespace-only passage blocks
- keep server-shaped passage text uncapped

On the captured `how to use io uring in rust` response, the current-source formatter drops from 3,580 to 3,413 `o200k_base` tokens, a 4.7% reduction.

## Verification

- `pnpm run lint`
- `pnpm run test` (74 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Developer search output no longer prints a duplicate bare URL when it’s already in the result ID and no longer inserts '---' between empty passages. This trims noise and reduces token usage while keeping server-shaped passages intact.

**Bug Fixes**
- Skip printing the bare URL when it already appears in the result ID; keep it when different (e.g., base vs child).
- Drop empty or whitespace-only passages to avoid stray '---' separators.
- Preserve server-shaped passages in full (no client-side capping).
- On the captured "how to use io uring in rust" response, output drops from 3,580 to 3,413 `o200k_base` tokens (~4.7%).

<sup>Written for commit d3cea15addff80e9fa68098d03a652e1ada5b418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

