### PR TITLE
fix(auth): bypass introspection for API keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -675,7 +675,14 @@ async function authenticateRequest(
   }
 
   const session: SessionData = {
-    authType: resolved?.source === 'oauth' ? 'oauth' : credential ? 'env' : 'none',
+    authType:
+      resolved?.source === 'oauth'
+        ? 'oauth'
+        : resolved?.source === 'api-key'
+          ? 'api-key'
+          : credential
+            ? 'env'
+            : 'none',
     firecrawlApiKey: headerCred ?? envCred,
     ...resolved?.metadata,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -418,19 +418,6 @@ function credentialMetadata(data: OAuthIntrospectionResponse): CredentialMetadat
   };
 }
 
-/**
- * The authorization server gave us no usable answer, so there is nothing to
- * enrich a session with. `introspect_unusable_credential` is deliberately not
- * included: that one means it did answer, and an answer we cannot use should
- * still fail closed rather than be treated as an absent one.
- */
-function isIntrospectionUnavailable(error: unknown): boolean {
-  return (
-    error instanceof CredentialValidationUnavailableError &&
-    error.diagnostics.reason !== 'introspect_unusable_credential'
-  );
-}
-
 async function introspectToken(
   token: string,
   expectedResource: string
@@ -556,7 +543,13 @@ async function resolveCredentialFromHeaders(
   if (isFirecrawlApiKey(token)) {
     const enrichment = await introspectToken(token, profile.resourceUrl).catch(
       (error: unknown) => {
-        if (isIntrospectionUnavailable(error)) return null;
+        // Every way introspection can fail to produce usable enrichment is the
+        // same thing here, including a well-formed `active` answer whose payload
+        // we cannot use. None of them is a verdict on the key, so none should
+        // deny a credential Core can validate on its own. A verdict does arrive
+        // as a value, not a throw: `active: false` and a non-general purpose are
+        // both handled below.
+        if (error instanceof CredentialValidationUnavailableError) return null;
         throw error;
       }
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -418,6 +418,19 @@ function credentialMetadata(data: OAuthIntrospectionResponse): CredentialMetadat
   };
 }
 
+/**
+ * The authorization server gave us no usable answer, so there is nothing to
+ * enrich a session with. `introspect_unusable_credential` is deliberately not
+ * included: that one means it did answer, and an answer we cannot use should
+ * still fail closed rather than be treated as an absent one.
+ */
+function isIntrospectionUnavailable(error: unknown): boolean {
+  return (
+    error instanceof CredentialValidationUnavailableError &&
+    error.diagnostics.reason !== 'introspect_unusable_credential'
+  );
+}
+
 async function introspectToken(
   token: string,
   expectedResource: string
@@ -530,14 +543,32 @@ async function resolveCredentialFromHeaders(
     return { invalid: true };
   }
 
-  // An API key is already the credential Core authenticates, so introspection
-  // resolved it to itself. That round trip bought no authorization decision
-  // Core does not make on every call, while putting each request behind a third
-  // service. Forward it and let Core be the authority; a rejection comes back as
-  // the CREDENTIAL_INVALID recovery at the tool boundary. OAuth access tokens
-  // still require introspection, because Core cannot resolve one on its own.
+  // Core authenticates an API key on every call, so introspecting one resolves
+  // it to itself. What the round trip adds is enrichment, the credential_purpose
+  // check and the account attribution the action log records, not an
+  // authorization decision Core does not already make. Treat an authorization
+  // server that cannot answer as missing enrichment rather than a failed
+  // request, and let Core be the authority on the key. An answer we did get is
+  // still honoured, so behaviour is unchanged whenever introspection works.
+  //
+  // OAuth access tokens keep the strict path below: Core cannot resolve one on
+  // its own, so there is nothing to fall back to.
   if (isFirecrawlApiKey(token)) {
-    return { credential: token, source: 'api-key' };
+    const enrichment = await introspectToken(token, profile.resourceUrl).catch(
+      (error: unknown) => {
+        if (isIntrospectionUnavailable(error)) return null;
+        throw error;
+      }
+    );
+    if (!enrichment) return { credential: token, source: 'api-key' };
+    if (!enrichment.active || !enrichment.api_key) return { invalid: true };
+    return enrichment.credential_purpose === 'general'
+      ? {
+          credential: enrichment.api_key,
+          metadata: credentialMetadata(enrichment),
+          source: 'api-key',
+        }
+      : { invalid: true };
   }
 
   let data = await introspectToken(token, profile.resourceUrl);

--- a/src/index.ts
+++ b/src/index.ts
@@ -530,6 +530,16 @@ async function resolveCredentialFromHeaders(
     return { invalid: true };
   }
 
+  // An API key is already the credential Core authenticates, so introspection
+  // resolved it to itself. That round trip bought no authorization decision
+  // Core does not make on every call, while putting each request behind a third
+  // service. Forward it and let Core be the authority; a rejection comes back as
+  // the CREDENTIAL_INVALID recovery at the tool boundary. OAuth access tokens
+  // still require introspection, because Core cannot resolve one on its own.
+  if (isFirecrawlApiKey(token)) {
+    return { credential: token, source: 'api-key' };
+  }
+
   let data = await introspectToken(token, profile.resourceUrl);
   if (
     isFirecrawlOAuthAccessToken(token) &&
@@ -539,20 +549,7 @@ async function resolveCredentialFromHeaders(
     data = await introspectToken(token, DEFAULT_MCP_RESOURCE_URL);
   }
   if (!data.active || !data.api_key) {
-    if (isFirecrawlOAuthAccessToken(token)) {
-      throw new InvalidOAuthCredentialError();
-    }
-    return { invalid: true };
-  }
-
-  if (isFirecrawlApiKey(token)) {
-    return data.credential_purpose === 'general'
-      ? {
-          credential: data.api_key,
-          source: 'api-key',
-          metadata: credentialMetadata(data),
-        }
-      : { invalid: true };
+    throw new InvalidOAuthCredentialError();
   }
   const expectedAudience =
     profile.acceptLegacyAudience &&
@@ -1127,6 +1124,46 @@ function invalidOAuthRecoveryPayload(): Record<string, unknown> & { message: str
   });
 }
 
+/**
+ * Core rejected the credential this session forwarded. Tools reach Core two
+ * ways: the SDK helpers raise FirecrawlSdkError, while firecrawl_search posts
+ * through the SDK's axios layer to keep the full response envelope. Both carry
+ * the upstream status. Only 401 is matched, because that is a verdict on the
+ * credential; a 403 can mean an entitlement the key legitimately lacks.
+ */
+function isCoreCredentialRejection(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const candidate = error as {
+    isAxiosError?: unknown;
+    name?: string;
+    response?: { status?: unknown };
+    status?: unknown;
+  };
+  if (candidate.name !== 'FirecrawlSdkError' && candidate.isAxiosError !== true) {
+    return false;
+  }
+  return candidate.status === 401 || candidate.response?.status === 401;
+}
+
+/**
+ * API keys reach Core unresolved, so an invalid one is discovered when a tool
+ * runs rather than at connect time. Translate that rejection into the same
+ * CREDENTIAL_INVALID recovery the agent already knows how to act on, so the
+ * guidance does not depend on having introspected the key first.
+ */
+async function runWithCredentialRecovery<T>(
+  run: () => T | Promise<T>,
+  requestId: string
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (!isCoreCredentialRejection(error)) throw error;
+    const payload = recoveryPayload('CREDENTIAL_INVALID', requestId);
+    throw new UserError(String(payload.message), payload);
+  }
+}
+
 function recoveryPayload(
   code: string,
   requestId: string = randomUUID(),
@@ -1333,11 +1370,16 @@ function guardHostedTool(
         if (logActions) emitActionLog(tool.name, 'error', invocationSession, new UserError(String(payload.message), payload), requestId, code);
         throw new UserError(String(payload.message), payload);
       }
-      if (!logActions) return execute(args, invocationContext);
+      const runTool = () =>
+        runWithCredentialRecovery(
+          () => execute(args, invocationContext),
+          requestId
+        );
+      if (!logActions) return runTool();
 
       emitActionLog(tool.name, 'started', invocationSession, undefined, requestId);
       try {
-        const result = await execute(args, invocationContext);
+        const result = await runTool();
         emitActionLog(tool.name, 'success', invocationSession, undefined, requestId);
         return result;
       } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { escapeWWWAuthenticateValue } from './www-authenticate';
 import {
   credentialForOutboundRequest,
   copyManagedOAuthApiKey,
+  CoreHttpError,
   credentialValidationUnavailable,
   CredentialValidationUnavailableError,
   hasCredential,
@@ -543,12 +544,8 @@ async function resolveCredentialFromHeaders(
   if (isFirecrawlApiKey(token)) {
     const enrichment = await introspectToken(token, profile.resourceUrl).catch(
       (error: unknown) => {
-        // Every way introspection can fail to produce usable enrichment is the
-        // same thing here, including a well-formed `active` answer whose payload
-        // we cannot use. None of them is a verdict on the key, so none should
-        // deny a credential Core can validate on its own. A verdict does arrive
-        // as a value, not a throw: `active: false` and a non-general purpose are
-        // both handled below.
+        // A verdict arrives as a value, not a throw, so every throw here is a
+        // failure to enrich rather than a judgement on the key.
         if (error instanceof CredentialValidationUnavailableError) return null;
         throw error;
       }
@@ -558,8 +555,8 @@ async function resolveCredentialFromHeaders(
     return enrichment.credential_purpose === 'general'
       ? {
           credential: enrichment.api_key,
-          metadata: credentialMetadata(enrichment),
           source: 'api-key',
+          metadata: credentialMetadata(enrichment),
         }
       : { invalid: true };
   }
@@ -1149,23 +1146,19 @@ function invalidOAuthRecoveryPayload(): Record<string, unknown> & { message: str
 }
 
 /**
- * Core rejected the credential this session forwarded. Tools reach Core two
- * ways: the SDK helpers raise FirecrawlSdkError, while firecrawl_search posts
- * through the SDK's axios layer to keep the full response envelope. Both carry
- * the upstream status. Only 401 is matched, because that is a verdict on the
- * credential; a 403 can mean an entitlement the key legitimately lacks.
+ * Core rejected the credential this session forwarded. Tools reach Core by
+ * several routes, the SDK helpers, the SDK's HTTP layer, and plain fetch, so
+ * this reads the status rather than the error's type: every route reports one,
+ * and inside a tool a 401 can only have come from Core. Only 401 is matched,
+ * because that is a verdict on the credential; a 403 can mean an entitlement
+ * the key legitimately lacks.
  */
 function isCoreCredentialRejection(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const candidate = error as {
-    isAxiosError?: unknown;
-    name?: string;
     response?: { status?: unknown };
     status?: unknown;
   };
-  if (candidate.name !== 'FirecrawlSdkError' && candidate.isAxiosError !== true) {
-    return false;
-  }
   return candidate.status === 401 || candidate.response?.status === 401;
 }
 
@@ -1177,12 +1170,19 @@ function isCoreCredentialRejection(error: unknown): boolean {
  */
 async function runWithCredentialRecovery<T>(
   run: () => T | Promise<T>,
-  requestId: string
+  requestId: string,
+  session?: SessionData
 ): Promise<T> {
   try {
     return await run();
   } catch (error) {
-    if (!isCoreCredentialRejection(error)) throw error;
+    // Only an API-key session hands Core a credential nothing resolved first.
+    // An OAuth session was validated at connect time, so a rejection there is a
+    // different fault and keeps its own reconnect guidance; a keyless session
+    // never sent an account credential at all.
+    if (session?.authType !== 'api-key' || !isCoreCredentialRejection(error)) {
+      throw error;
+    }
     const payload = recoveryPayload('CREDENTIAL_INVALID', requestId);
     throw new UserError(String(payload.message), payload);
   }
@@ -1397,7 +1397,8 @@ function guardHostedTool(
       const runTool = () =>
         runWithCredentialRecovery(
           () => execute(args, invocationContext),
-          requestId
+          requestId,
+          invocationSession
         );
       if (!logActions) return runTool();
 
@@ -1933,10 +1934,11 @@ async function apiPostJson(
     parsed = { raw: responseText };
   }
   if (!response.ok) {
-    throw new Error(
+    throw new CoreHttpError(
       parsed?.error ||
         parsed?.message ||
-        `Firecrawl request failed (HTTP ${response.status})`
+        `Firecrawl request failed (HTTP ${response.status})`,
+      response.status
     );
   }
   return parsed;

--- a/src/index.ts
+++ b/src/index.ts
@@ -531,34 +531,12 @@ async function resolveCredentialFromHeaders(
     return { invalid: true };
   }
 
-  // Core authenticates an API key on every call, so introspecting one resolves
-  // it to itself. What the round trip adds is enrichment, the credential_purpose
-  // check and the account attribution the action log records, not an
-  // authorization decision Core does not already make. Treat an authorization
-  // server that cannot answer as missing enrichment rather than a failed
-  // request, and let Core be the authority on the key. An answer we did get is
-  // still honoured, so behaviour is unchanged whenever introspection works.
-  //
-  // OAuth access tokens keep the strict path below: Core cannot resolve one on
-  // its own, so there is nothing to fall back to.
+  // An API key is already the credential Core authenticates, so introspection
+  // resolves it to itself. Forward it unchanged and let Core be the authority;
+  // a 401 becomes CREDENTIAL_INVALID at the tool boundary. OAuth access tokens
+  // keep the strict path below because Core cannot resolve them on its own.
   if (isFirecrawlApiKey(token)) {
-    const enrichment = await introspectToken(token, profile.resourceUrl).catch(
-      (error: unknown) => {
-        // A verdict arrives as a value, not a throw, so every throw here is a
-        // failure to enrich rather than a judgement on the key.
-        if (error instanceof CredentialValidationUnavailableError) return null;
-        throw error;
-      }
-    );
-    if (!enrichment) return { credential: token, source: 'api-key' };
-    if (!enrichment.active || !enrichment.api_key) return { invalid: true };
-    return enrichment.credential_purpose === 'general'
-      ? {
-          credential: enrichment.api_key,
-          source: 'api-key',
-          metadata: credentialMetadata(enrichment),
-        }
-      : { invalid: true };
+    return { credential: token, source: 'api-key' };
   }
 
   let data = await introspectToken(token, profile.resourceUrl);
@@ -2631,9 +2609,18 @@ Eligibility is limited to successful searches within the feedback age window. Th
         parsed = { raw: responseText };
       }
 
-      // 4xx is terminal; surface a structured payload (with retryable=false)
-      // so agents do not retry-loop on substantive-feedback rejections,
-      // expired windows, etc.
+      // A 401 is Core's verdict on the forwarded API key, so let the shared
+      // credential-recovery boundary turn it into CREDENTIAL_INVALID.
+      if (session?.authType === 'api-key' && response.status === 401) {
+        throw new CoreHttpError(
+          parsed?.error ?? 'Unauthorized: invalid Firecrawl API key',
+          response.status
+        );
+      }
+
+      // Other 4xx responses are terminal; surface a structured payload (with
+      // retryable=false) so agents do not retry-loop on substantive-feedback
+      // rejections, expired windows, etc.
       if (!response.ok) {
         log.warn('Search feedback rejected', {
           status: response.status,
@@ -2757,6 +2744,15 @@ Returns submission status, feedback ID, and accounting fields.
         parsed = JSON.parse(responseText);
       } catch {
         parsed = { raw: responseText };
+      }
+
+      // A 401 is Core's verdict on the forwarded API key, so let the shared
+      // credential-recovery boundary turn it into CREDENTIAL_INVALID.
+      if (session?.authType === 'api-key' && response.status === 401) {
+        throw new CoreHttpError(
+          parsed?.error ?? 'Unauthorized: invalid Firecrawl API key',
+          response.status
+        );
       }
 
       if (!response.ok) {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -12,6 +12,7 @@
 import { z } from 'zod';
 import type { FastMCP } from 'fastmcp';
 import {
+  CoreHttpError,
   credentialForOutboundRequest,
   type CredentialSession,
 } from './session-credential';
@@ -82,7 +83,7 @@ async function monitorRequest(
     const message =
       payload?.error ||
       `HTTP ${response.status}: ${response.statusText || 'Request failed'}`;
-    throw new Error(message);
+    throw new CoreHttpError(message, response.status);
   }
 
   return payload;

--- a/src/session-credential.ts
+++ b/src/session-credential.ts
@@ -14,6 +14,21 @@ export interface CredentialSession {
 }
 
 /**
+ * A non-2xx answer from Core on a path that does not go through the SDK. The
+ * status travels with the error so a credential rejection stays recognisable
+ * wherever it was raised, rather than being inferred from a message string.
+ */
+export class CoreHttpError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'CoreHttpError';
+    this.status = status;
+  }
+}
+
+/**
  * Names the validation step that failed. Deliberately low cardinality and
  * server-side only: these tags are for operators triaging a credential
  * validation outage, and they never carry credential material.

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -151,6 +151,14 @@ async function startFakeBackend(options = {}) {
       return;
     }
 
+    // Core is the authority on a forwarded API key, so the suite's invalid keys
+    // are rejected here rather than at introspection.
+    if ((req.headers.authorization ?? '').includes('invalid')) {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Unauthorized: Invalid token', success: false }));
+      return;
+    }
+
     if (req.method === 'POST' && req.url === '/v2/search') {
       // The developer category is an extra arm: the API returns its hits in a
       // `data.developer` group beside the web results.
@@ -488,27 +496,22 @@ test('search surface requires authentication for tools/list', async (t) => {
   assert.match(wwwAuthenticate, /error="invalid_token"/);
 });
 
-test('search surface rejects an invalid raw API credential during tools/list', async (t) => {
+test('search surface admits a well-formed API key without resolving it first', async (t) => {
   const { searchPort } = await startHostedServer(t);
 
+  // Core authenticates the key on every call, so listing tools no longer waits
+  // on the authorization server. The verdict arrives when a tool runs.
   const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
     id: 8,
     method: 'tools/list',
     headers: { 'x-api-key': 'fc-invalid' },
   });
-  assert.equal(res.status, 401);
-  assert.equal(res.headers.has('www-authenticate'), false);
-  const body = await res.json();
-  assert.equal(body.error, 'invalid_api_key');
-  assert.equal(body.code, 'CREDENTIAL_INVALID');
-  assert.equal(
-    body.error_description,
-    INVALID_API_KEY_MESSAGE
-  );
-  assert.equal(body.next_actions, undefined);
+  assert.equal(res.status, 200);
+  const message = parseSseJson(await res.text());
+  assert.ok((message.result?.tools?.length ?? 0) > 0);
 });
 
-test('search surface rejects an invalid raw API credential before a tool call', async (t) => {
+test('search surface turns a Core credential rejection into agent-legible recovery', async (t) => {
   const backend = await startFakeBackend();
   t.after(() => backend.close());
   const { searchPort } = await startHostedServer(t, {
@@ -524,17 +527,17 @@ test('search surface rejects an invalid raw API credential before a tool call', 
     },
     headers: { 'x-api-key': 'fc-invalid' },
   });
-  assert.equal(res.status, 401);
+  // A 200 isError result reaches the model; a transport 401 would not.
+  assert.equal(res.status, 200);
   assert.equal(res.headers.has('www-authenticate'), false);
-  const body = await res.json();
-  assert.equal(body.error, 'invalid_api_key');
-  assert.equal(body.code, 'CREDENTIAL_INVALID');
-  assert.equal(
-    body.error_description,
-    INVALID_API_KEY_MESSAGE
-  );
-  assert.equal(body.next_actions, undefined);
-  assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
+  const result = parseSseJson(await res.text()).result;
+  assert.equal(result.isError, true);
+  assert.equal(result.content[0].text, INVALID_API_KEY_MESSAGE);
+  assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID');
+  assert.equal(result.structuredContent.message, INVALID_API_KEY_MESSAGE);
+  assert.equal(result.structuredContent.next_actions, undefined);
+  // The key reached Core, which is what produced the verdict.
+  assert.equal(backend.requests.some((r) => r.url === '/v2/search'), true);
 });
 
 test('search surface serves path-scoped protected-resource metadata', async (t) => {
@@ -915,12 +918,15 @@ test('companion telemetry follows credential precedence and rejects invalid cred
     authorization: 'Bearer fco_secondary-credential',
     'x-api-key': 'fc-primary-credential',
   });
+  // A well-formed key is admitted here and judged by Core, so the connect-time
+  // outcome is accepted for both. Precedence and sanitization are what this
+  // record exists to prove.
   const invalid = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
     id: 12,
     method: 'tools/list',
     headers: { authorization: 'Bearer fc-invalid-credential' },
   });
-  assert.equal(invalid.status, 401);
+  assert.equal(invalid.status, 200);
   await delay(25);
 
   const events = getStdout()
@@ -931,7 +937,7 @@ test('companion telemetry follows credential precedence and rejects invalid cred
     events.map(({ auth_mode, outcome }) => ({ auth_mode, outcome })),
     [
       { auth_mode: 'api-key', outcome: 'accepted' },
-      { auth_mode: 'api-key', outcome: 'rejected' },
+      { auth_mode: 'api-key', outcome: 'accepted' },
     ]
   );
   assert.doesNotMatch(getStdout(), /fc-primary-credential|fco_secondary-credential/);

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -911,7 +911,7 @@ test('companion emits sanitized auth-mode telemetry without credential material'
   assert.doesNotMatch(logs, /authorization/i);
 });
 
-test('companion telemetry follows credential precedence and rejects invalid credentials', async (t) => {
+test('companion telemetry follows credential precedence for admitted API keys', async (t) => {
   const { searchPort, getStdout } = await startHostedServer(t);
 
   await listTools(searchPort, SEARCH_ENDPOINT, {

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -151,6 +151,13 @@ async function startFakeBackend(options = {}) {
       return;
     }
 
+    // Core, not introspection, decides whether a forwarded API key is valid.
+    if (/Bearer fc-\S*invalid/.test(req.headers.authorization ?? '')) {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Unauthorized: Invalid token', success: false }));
+      return;
+    }
+
     if (req.method === 'POST' && req.url === '/v2/search') {
       // The developer category is an extra arm: the API returns its hits in a
       // `data.developer` group beside the web results.
@@ -233,6 +240,7 @@ async function startHostedServer(t, extraEnv = {}) {
   t.after(() => stopChild(child));
   await waitForHealth(searchPort, child);
   return {
+    backendRequests: defaultBackend.requests,
     child,
     fullPort,
     searchPort,
@@ -268,6 +276,7 @@ async function startPrimarySearchServer(t, extraEnv = {}) {
   t.after(() => stopChild(child));
   await waitForHealth(port, child);
   return {
+    backendRequests: defaultBackend.requests,
     child,
     getStderr: () => stderr,
     issuerUrl: extraEnv.FIRECRAWL_OAUTH_ISSUER ?? defaultBackend.url,
@@ -488,31 +497,31 @@ test('search surface requires authentication for tools/list', async (t) => {
   assert.match(wwwAuthenticate, /error="invalid_token"/);
 });
 
-test('search surface rejects an invalid raw API credential during tools/list', async (t) => {
-  const { searchPort } = await startHostedServer(t);
+test('search companion admits a well-formed API key without introspection', async (t) => {
+  const { backendRequests, searchPort } = await startHostedServer(t);
 
+  // Core authenticates the key when a tool runs. tools/list must not depend on
+  // the OAuth issuer or claim to know whether the raw key is valid.
   const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
     id: 8,
     method: 'tools/list',
     headers: { 'x-api-key': 'fc-invalid' },
   });
-  assert.equal(res.status, 401);
-  assert.equal(res.headers.has('www-authenticate'), false);
-  const body = await res.json();
-  assert.equal(body.error, 'invalid_api_key');
-  assert.equal(body.code, 'CREDENTIAL_INVALID');
+  assert.equal(res.status, 200);
+  const message = parseSseJson(await res.text());
+  assert.ok((message.result?.tools?.length ?? 0) > 0);
   assert.equal(
-    body.error_description,
-    INVALID_API_KEY_MESSAGE
+    backendRequests.filter((request) => request.url === '/api/oauth/introspect').length,
+    0
   );
-  assert.equal(body.next_actions, undefined);
 });
 
-test('search surface rejects an invalid raw API credential before a tool call', async (t) => {
+test('search companion turns a Core credential rejection into recovery', async (t) => {
   const backend = await startFakeBackend();
   t.after(() => backend.close());
   const { searchPort } = await startHostedServer(t, {
     FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
   });
 
   const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
@@ -524,17 +533,19 @@ test('search surface rejects an invalid raw API credential before a tool call', 
     },
     headers: { 'x-api-key': 'fc-invalid' },
   });
-  assert.equal(res.status, 401);
+  assert.equal(res.status, 200);
   assert.equal(res.headers.has('www-authenticate'), false);
-  const body = await res.json();
-  assert.equal(body.error, 'invalid_api_key');
-  assert.equal(body.code, 'CREDENTIAL_INVALID');
+  const result = parseSseJson(await res.text()).result;
+  assert.equal(result.isError, true);
+  assert.equal(result.content[0].text, INVALID_API_KEY_MESSAGE);
+  assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID');
+  assert.equal(result.structuredContent.message, INVALID_API_KEY_MESSAGE);
+  assert.equal(result.structuredContent.next_actions, undefined);
+  assert.equal(backend.requests.some((request) => request.url === '/v2/search'), true);
   assert.equal(
-    body.error_description,
-    INVALID_API_KEY_MESSAGE
+    backend.requests.filter((request) => request.url === '/api/oauth/introspect').length,
+    0
   );
-  assert.equal(body.next_actions, undefined);
-  assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
 });
 
 test('search surface serves path-scoped protected-resource metadata', async (t) => {
@@ -626,7 +637,7 @@ test('search surface accepts a token minted for its own resource', async (t) => 
 });
 
 test('full surface still exposes its complete tool set alongside the search surface', async (t) => {
-  const { fullPort } = await startHostedServer(t);
+  const { backendRequests, fullPort } = await startHostedServer(t);
 
   // Full surface is reachable on its own port with all tools intact.
   const names = await listTools(fullPort, '/v2/mcp', { 'x-api-key': 'fc-test' });
@@ -635,6 +646,11 @@ test('full surface still exposes its complete tool set alongside the search surf
   assert.ok(names.includes('firecrawl_developer_search'));
   assert.ok(names.includes('firecrawl_parse'));
   assert.ok(names.length > SEARCH_TOOLS.length);
+  assert.equal(
+    backendRequests.filter((request) => request.url === '/api/oauth/introspect').length,
+    0,
+    'the full route must not introspect raw API keys'
+  );
 
   // The anonymous full surface accepts credentials but does not advertise
   // OAuth, so clients do not start login while configuring keyless MCP.
@@ -645,7 +661,7 @@ test('full surface still exposes its complete tool set alongside the search surf
 });
 
 test('primary search profile is OAuth-only, six-tool frozen, and ready without keyless configuration', async (t) => {
-  const { port, issuerUrl } = await startPrimarySearchServer(t);
+  const { backendRequests, port, issuerUrl } = await startPrimarySearchServer(t);
 
   const ready = await fetch(`http://127.0.0.1:${port}/ready`);
   assert.equal(ready.status, 200);
@@ -677,6 +693,11 @@ test('primary search profile is OAuth-only, six-tool frozen, and ready without k
     assert.equal(response.status, 401, JSON.stringify(headers));
     assert.match(response.headers.get('www-authenticate') ?? '', /Bearer /);
   }
+  assert.equal(
+    backendRequests.filter((request) => request.url === '/api/oauth/introspect').length,
+    0,
+    'the OAuth-only route must reject raw API keys without introspection'
+  );
 
   const prm = await fetch(
     `http://127.0.0.1:${port}/.well-known/oauth-protected-resource${SEARCH_ENDPOINT}`
@@ -908,19 +929,19 @@ test('companion emits sanitized auth-mode telemetry without credential material'
   assert.doesNotMatch(logs, /authorization/i);
 });
 
-test('companion telemetry follows credential precedence and rejects invalid credentials', async (t) => {
+test('companion telemetry follows credential precedence without resolving API keys', async (t) => {
   const { searchPort, getStdout } = await startHostedServer(t);
 
   await listTools(searchPort, SEARCH_ENDPOINT, {
     authorization: 'Bearer fco_secondary-credential',
     'x-api-key': 'fc-primary-credential',
   });
-  const invalid = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+  const unresolved = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
     id: 12,
     method: 'tools/list',
     headers: { authorization: 'Bearer fc-invalid-credential' },
   });
-  assert.equal(invalid.status, 401);
+  assert.equal(unresolved.status, 200);
   await delay(25);
 
   const events = getStdout()
@@ -931,7 +952,7 @@ test('companion telemetry follows credential precedence and rejects invalid cred
     events.map(({ auth_mode, outcome }) => ({ auth_mode, outcome })),
     [
       { auth_mode: 'api-key', outcome: 'accepted' },
-      { auth_mode: 'api-key', outcome: 'rejected' },
+      { auth_mode: 'api-key', outcome: 'accepted' },
     ]
   );
   assert.doesNotMatch(getStdout(), /fc-primary-credential|fco_secondary-credential/);

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -151,14 +151,6 @@ async function startFakeBackend(options = {}) {
       return;
     }
 
-    // Core is the authority on a forwarded API key, so the suite's invalid keys
-    // are rejected here rather than at introspection.
-    if ((req.headers.authorization ?? '').includes('invalid')) {
-      res.writeHead(401, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Unauthorized: Invalid token', success: false }));
-      return;
-    }
-
     if (req.method === 'POST' && req.url === '/v2/search') {
       // The developer category is an extra arm: the API returns its hits in a
       // `data.developer` group beside the web results.
@@ -496,22 +488,27 @@ test('search surface requires authentication for tools/list', async (t) => {
   assert.match(wwwAuthenticate, /error="invalid_token"/);
 });
 
-test('search surface admits a well-formed API key without resolving it first', async (t) => {
+test('search surface rejects an invalid raw API credential during tools/list', async (t) => {
   const { searchPort } = await startHostedServer(t);
 
-  // Core authenticates the key on every call, so listing tools no longer waits
-  // on the authorization server. The verdict arrives when a tool runs.
   const res = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
     id: 8,
     method: 'tools/list',
     headers: { 'x-api-key': 'fc-invalid' },
   });
-  assert.equal(res.status, 200);
-  const message = parseSseJson(await res.text());
-  assert.ok((message.result?.tools?.length ?? 0) > 0);
+  assert.equal(res.status, 401);
+  assert.equal(res.headers.has('www-authenticate'), false);
+  const body = await res.json();
+  assert.equal(body.error, 'invalid_api_key');
+  assert.equal(body.code, 'CREDENTIAL_INVALID');
+  assert.equal(
+    body.error_description,
+    INVALID_API_KEY_MESSAGE
+  );
+  assert.equal(body.next_actions, undefined);
 });
 
-test('search surface turns a Core credential rejection into agent-legible recovery', async (t) => {
+test('search surface rejects an invalid raw API credential before a tool call', async (t) => {
   const backend = await startFakeBackend();
   t.after(() => backend.close());
   const { searchPort } = await startHostedServer(t, {
@@ -527,17 +524,17 @@ test('search surface turns a Core credential rejection into agent-legible recove
     },
     headers: { 'x-api-key': 'fc-invalid' },
   });
-  // A 200 isError result reaches the model; a transport 401 would not.
-  assert.equal(res.status, 200);
+  assert.equal(res.status, 401);
   assert.equal(res.headers.has('www-authenticate'), false);
-  const result = parseSseJson(await res.text()).result;
-  assert.equal(result.isError, true);
-  assert.equal(result.content[0].text, INVALID_API_KEY_MESSAGE);
-  assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID');
-  assert.equal(result.structuredContent.message, INVALID_API_KEY_MESSAGE);
-  assert.equal(result.structuredContent.next_actions, undefined);
-  // The key reached Core, which is what produced the verdict.
-  assert.equal(backend.requests.some((r) => r.url === '/v2/search'), true);
+  const body = await res.json();
+  assert.equal(body.error, 'invalid_api_key');
+  assert.equal(body.code, 'CREDENTIAL_INVALID');
+  assert.equal(
+    body.error_description,
+    INVALID_API_KEY_MESSAGE
+  );
+  assert.equal(body.next_actions, undefined);
+  assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
 });
 
 test('search surface serves path-scoped protected-resource metadata', async (t) => {
@@ -911,22 +908,19 @@ test('companion emits sanitized auth-mode telemetry without credential material'
   assert.doesNotMatch(logs, /authorization/i);
 });
 
-test('companion telemetry follows credential precedence for admitted API keys', async (t) => {
+test('companion telemetry follows credential precedence and rejects invalid credentials', async (t) => {
   const { searchPort, getStdout } = await startHostedServer(t);
 
   await listTools(searchPort, SEARCH_ENDPOINT, {
     authorization: 'Bearer fco_secondary-credential',
     'x-api-key': 'fc-primary-credential',
   });
-  // A well-formed key is admitted here and judged by Core, so the connect-time
-  // outcome is accepted for both. Precedence and sanitization are what this
-  // record exists to prove.
   const invalid = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
     id: 12,
     method: 'tools/list',
     headers: { authorization: 'Bearer fc-invalid-credential' },
   });
-  assert.equal(invalid.status, 200);
+  assert.equal(invalid.status, 401);
   await delay(25);
 
   const events = getStdout()
@@ -937,7 +931,7 @@ test('companion telemetry follows credential precedence for admitted API keys', 
     events.map(({ auth_mode, outcome }) => ({ auth_mode, outcome })),
     [
       { auth_mode: 'api-key', outcome: 'accepted' },
-      { auth_mode: 'api-key', outcome: 'accepted' },
+      { auth_mode: 'api-key', outcome: 'rejected' },
     ]
   );
   assert.doesNotMatch(getStdout(), /fc-primary-credential|fco_secondary-credential/);

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1933,14 +1933,38 @@ test('account readiness requires the managed OAuth delegation secret', async (t)
 test('credential validation outages do not misdirect clients into OAuth', async (t) => {
   const backend = await startFakeFirecrawlBackend();
   t.after(() => backend.close());
-  const unavailableIssuerPort = await getFreePort();
+
+  let introspectionCalls = 0;
+  const issuer = createServer((request, response) => {
+    if (request.method === 'POST' && request.url === '/api/oauth/introspect') {
+      introspectionCalls += 1;
+      response.destroy();
+      return;
+    }
+    response.writeHead(404);
+    response.end();
+  });
+  await new Promise((resolve, reject) => {
+    issuer.once('error', reject);
+    issuer.listen(0, '127.0.0.1', resolve);
+  });
+  t.after(
+    () =>
+      new Promise((resolve, reject) => {
+        issuer.close((error) => (error ? reject(error) : resolve()));
+      })
+  );
+  const issuerAddress = issuer.address();
+  assert.equal(typeof issuerAddress, 'object');
+  const issuerUrl = `http://127.0.0.1:${issuerAddress.port}`;
+
   const port = await getFreePort();
   const child = spawnServer({
     CLOUD_SERVICE: 'true',
     FASTMCP_ENDPOINT: '/v2/mcp-oauth',
     FIRECRAWL_API_URL: backend.url,
     FIRECRAWL_MCP_RESOURCE_URL: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
-    FIRECRAWL_OAUTH_ISSUER: `http://127.0.0.1:${unavailableIssuerPort}`,
+    FIRECRAWL_OAUTH_ISSUER: issuerUrl,
     FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
     HTTP_STREAMABLE_SERVER: 'true',
     PORT: String(port),
@@ -1977,13 +2001,18 @@ test('credential validation outages do not misdirect clients into OAuth', async 
   assert.equal(oauthRecord.resource, ACCOUNT_RESOURCE);
   assert.equal(typeof oauthRecord.elapsed_ms, 'number');
   assert.doesNotMatch(stderr, /fco_account_token/);
+  assert.equal(introspectionCalls, 1);
 
   // An API key never needs the issuer, so the same outage does not reach it.
   stderr = '';
   const apiKey = await listTools('fc-account-key');
   assert.equal(apiKey.status, 200);
   assert.match(await apiKey.text(), /firecrawl_scrape/);
-  await delay(150);
+  assert.equal(
+    introspectionCalls,
+    1,
+    'the API-key request must not make another introspection call'
+  );
   assert.doesNotMatch(stderr, /\[MCP_CREDENTIAL_VALIDATION\]/);
 });
 

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1989,6 +1989,45 @@ test('an unusable key still gets recovery when introspection cannot answer', asy
   assert.equal(result.structuredContent.message, INVALID_API_KEY_MESSAGE);
 });
 
+test('an API key survives an active introspection answer it cannot use', async (t) => {
+  // The answer is well formed enough to parse but carries no usable scope, so
+  // introspectToken raises introspect_unusable_credential. That is a statement
+  // about the answer, not about the key, so Core still gets to decide.
+  const backend = await startFakeFirecrawlBackend({
+    introspectionHandler: () => ({
+      active: true,
+      api_key: 'fc-account-key',
+      credential_purpose: 'general',
+      scope: '',
+    }),
+  });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const response = await fetch(`http://127.0.0.1:${port}/v2/mcp`, {
+    body: JSON.stringify({ id: 1, jsonrpc: '2.0', method: 'tools/list', params: {} }),
+    headers: {
+      accept: 'application/json, text/event-stream',
+      authorization: 'Bearer fc-account-key',
+      'content-type': 'application/json',
+    },
+    method: 'POST',
+  });
+  assert.equal(response.status, 200);
+  assert.match(await response.text(), /firecrawl_scrape/);
+});
+
 test('active introspection with an unknown credential purpose fails closed', async (t) => {
   const accountResource = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
   const backend = await startFakeFirecrawlBackend({

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -373,8 +373,10 @@ async function startFakeFirecrawlBackend(options = {}) {
     }
 
     // Core is the authority on a forwarded API key, so a key the suite marks
-    // invalid is rejected here rather than at introspection.
-    if ((req.headers.authorization ?? '').includes('invalid')) {
+    // invalid is rejected here rather than at introspection. Scoped to fc-
+    // credentials: an fco_ token never reaches Core, and matching it here would
+    // silently change unrelated tests.
+    if (/Bearer fc-\S*invalid/.test(req.headers.authorization ?? '')) {
       res.writeHead(401, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized: Invalid token', success: false }));
       return;
@@ -1953,6 +1955,10 @@ test('credential validation outages do not misdirect clients into OAuth', async 
   const keyRecord = await waitForCredentialValidationLog(() => stderr);
   assert.ok(keyRecord, `missing validation log in ${stderr}`);
   assert.equal(keyRecord.reason, 'introspect_transport_error');
+  assert.equal(keyRecord.introspect_status, null);
+  assert.equal(keyRecord.aborted, false);
+  assert.equal(keyRecord.resource, ACCOUNT_RESOURCE);
+  assert.equal(typeof keyRecord.elapsed_ms, 'number');
   assert.doesNotMatch(stderr, /fc-account-key/);
 });
 
@@ -2026,6 +2032,83 @@ test('an API key survives an active introspection answer it cannot use', async (
   });
   assert.equal(response.status, 200);
   assert.match(await response.text(), /firecrawl_scrape/);
+});
+
+test('a fetch-based tool maps a Core rejection to recovery like the SDK tools do', async (t) => {
+  // firecrawl_parse reaches Core through plain fetch rather than the SDK, so it
+  // exercises the path that reports its status through CoreHttpError.
+  const backend = await startFakeFirecrawlBackend();
+  t.after(() => backend.close());
+  const unreachableIssuerPort = await getFreePort();
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: `http://127.0.0.1:${unreachableIssuerPort}`,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const call = await httpToolCall(port, {
+    headers: { authorization: 'Bearer fc-invalid' },
+    id: 1,
+    params: {
+      arguments: {
+        contentType: 'application/pdf',
+        filePath: '/not-read-by-hosted-mcp/document.pdf',
+        formats: ['markdown'],
+        parsers: ['pdf'],
+      },
+      name: 'firecrawl_parse',
+    },
+  });
+  assert.equal(call.status, 200);
+  const result = parseSseJson(await call.text()).result;
+  assert.equal(result.isError, true);
+  assert.equal(result.content[0].text, INVALID_API_KEY_MESSAGE);
+  assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID');
+});
+
+test('an OAuth session keeps its own guidance when Core rejects the credential', async (t) => {
+  // The API-key recovery says to replace a key on this server, which is the
+  // wrong instruction for a session that authenticated by connecting an
+  // account. Only a session that forwarded an unresolved key should get it.
+  const backend = await startFakeFirecrawlBackend({
+    introspectionHandler: () => ({
+      active: true,
+      api_key: 'fc-invalid-resolved',
+      aud: 'https://mcp.firecrawl.dev/v2/mcp',
+      credential_purpose: 'general',
+      scope: 'firecrawl:global',
+    }),
+  });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const call = await httpToolCall(port, {
+    headers: { authorization: 'Bearer fco_resolved_token' },
+    id: 1,
+    params: { arguments: { query: 'x' }, name: 'firecrawl_search' },
+  });
+  const result = parseSseJson(await call.text()).result;
+  assert.equal(result.isError, true);
+  assert.notEqual(result.content[0].text, INVALID_API_KEY_MESSAGE);
+  assert.notEqual(result.structuredContent?.code, 'CREDENTIAL_INVALID');
 });
 
 test('active introspection with an unknown credential purpose fails closed', async (t) => {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1206,6 +1206,77 @@ test('HTTP transport returns invalid OAuth recovery without an OAuth challenge w
   assert.equal(backend.requests.some((request) => request.url === '/v2/search'), false);
 });
 
+test('local HTTP header API keys receive Core credential recovery', async (t) => {
+  const backend = await startFakeFirecrawlBackend();
+  t.after(() => backend.close());
+
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'false',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_KEY: '',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_TOKEN: '',
+    HOST: '127.0.0.1',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const response = await httpToolCall(port, {
+    headers: { 'x-firecrawl-api-key': 'fc-invalid' },
+    id: 'local-http-invalid-header-key',
+    params: {
+      arguments: { limit: 1, query: 'example domain' },
+      name: 'firecrawl_search',
+    },
+  });
+  assert.equal(response.status, 200);
+  const result = parseSseJson(await response.text()).result;
+  assert.equal(result.isError, true);
+  assert.equal(result.content[0].text, INVALID_API_KEY_MESSAGE);
+  assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID');
+  assert.equal(backend.requests.some((request) => request.url === '/v2/search'), true);
+  assert.equal(
+    backend.requests.filter((request) => request.url === '/api/oauth/introspect').length,
+    0
+  );
+});
+
+test('local HTTP environment credentials keep self-hosted Core errors', async (t) => {
+  const backend = await startFakeFirecrawlBackend();
+  t.after(() => backend.close());
+
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'false',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_KEY: 'fc-invalid',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_TOKEN: '',
+    HOST: '127.0.0.1',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const response = await httpToolCall(port, {
+    id: 'local-http-invalid-env-key',
+    params: {
+      arguments: { limit: 1, query: 'example domain' },
+      name: 'firecrawl_search',
+    },
+  });
+  assert.equal(response.status, 200);
+  const result = parseSseJson(await response.text()).result;
+  assert.equal(result.isError, true);
+  assert.notEqual(result.content[0].text, INVALID_API_KEY_MESSAGE);
+  assert.notEqual(result.structuredContent?.code, 'CREDENTIAL_INVALID');
+  assert.equal(backend.requests.some((request) => request.url === '/v2/search'), true);
+});
+
 test('HTTP cloud transport accepts the x-firecrawl-api-key header', async (t) => {
   const backend = await startFakeFirecrawlBackend();
   t.after(() => backend.close());

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -372,8 +372,8 @@ async function startFakeFirecrawlBackend(options = {}) {
       return;
     }
 
-    // Core is the authority on a forwarded API key, so the suite's invalid keys
-    // are rejected here rather than at introspection.
+    // Core is the authority on a forwarded API key, so a key the suite marks
+    // invalid is rejected here rather than at introspection.
     if ((req.headers.authorization ?? '').includes('invalid')) {
       res.writeHead(401, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized: Invalid token', success: false }));
@@ -1928,29 +1928,65 @@ test('credential validation outages do not misdirect clients into OAuth', async 
       method: 'POST',
     });
 
-  // An OAuth access token cannot be resolved without the issuer, so it still
-  // fails closed.
+  // An OAuth access token has nothing to fall back to, so it still fails closed.
   stderr = '';
   const oauth = await listTools('fco_account_token');
   await assertCredentialValidationUnavailable(oauth, 'fco_account_token');
 
   // An unreachable issuer is a transport fault, not the abort budget firing.
-  const record = await waitForCredentialValidationLog(() => stderr);
-  assert.ok(record, `missing validation log in ${stderr}`);
-  assert.equal(record.reason, 'introspect_transport_error');
-  assert.equal(record.introspect_status, null);
-  assert.equal(record.aborted, false);
-  assert.equal(record.resource, ACCOUNT_RESOURCE);
-  assert.equal(typeof record.elapsed_ms, 'number');
+  const oauthRecord = await waitForCredentialValidationLog(() => stderr);
+  assert.ok(oauthRecord, `missing validation log in ${stderr}`);
+  assert.equal(oauthRecord.reason, 'introspect_transport_error');
+  assert.equal(oauthRecord.introspect_status, null);
+  assert.equal(oauthRecord.aborted, false);
+  assert.equal(oauthRecord.resource, ACCOUNT_RESOURCE);
+  assert.equal(typeof oauthRecord.elapsed_ms, 'number');
   assert.doesNotMatch(stderr, /fco_account_token/);
 
-  // An API key never needed the issuer, so the same outage does not reach it.
+  // An API key is enriched by introspection, not authorized by it, so the same
+  // outage costs it the enrichment and nothing else. The record is still
+  // emitted, so a failing dependency stays visible while users are unaffected.
   stderr = '';
   const apiKey = await listTools('fc-account-key');
   assert.equal(apiKey.status, 200);
   assert.match(await apiKey.text(), /firecrawl_scrape/);
-  await delay(150);
-  assert.doesNotMatch(stderr, /\[MCP_CREDENTIAL_VALIDATION\]/);
+  const keyRecord = await waitForCredentialValidationLog(() => stderr);
+  assert.ok(keyRecord, `missing validation log in ${stderr}`);
+  assert.equal(keyRecord.reason, 'introspect_transport_error');
+  assert.doesNotMatch(stderr, /fc-account-key/);
+});
+
+test('an unusable key still gets recovery when introspection cannot answer', async (t) => {
+  const backend = await startFakeFirecrawlBackend();
+  t.after(() => backend.close());
+  const unreachableIssuerPort = await getFreePort();
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: `http://127.0.0.1:${unreachableIssuerPort}`,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  // Introspection is unreachable, so the key reaches Core unresolved and Core
+  // supplies the verdict. The agent must still receive guidance it can act on
+  // rather than a raw upstream error.
+  const call = await httpToolCall(port, {
+    headers: { authorization: 'Bearer fc-invalid' },
+    id: 1,
+    params: { arguments: { query: 'x' }, name: 'firecrawl_search' },
+  });
+  assert.equal(call.status, 200);
+  const result = parseSseJson(await call.text()).result;
+  assert.equal(result.isError, true);
+  assert.equal(result.content[0].text, INVALID_API_KEY_MESSAGE);
+  assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID');
+  assert.equal(result.structuredContent.message, INVALID_API_KEY_MESSAGE);
 });
 
 test('active introspection with an unknown credential purpose fails closed', async (t) => {
@@ -2508,14 +2544,10 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
   const invalidLegacyJson = parseSseJson(await invalidLegacyPath.text());
   assert.ok((invalidLegacyJson.result?.tools?.length ?? 0) > 0);
   await delay(25);
-  // A well-formed API key is admitted at connect time now that Core owns the
-  // verdict, so the legacy-path record reports accepted and the correction is
-  // delivered by the tool call above. The record must still name no credential.
-  const legacyTelemetry = stdout
+  const rejectedTelemetry = stdout
     .split(/\r?\n/)
-    .find((line) => line.includes('[MCP_LEGACY_KEY_PATH]'));
-  assert.ok(legacyTelemetry, stdout);
-  assert.match(legacyTelemetry, /"outcome":"accepted"/);
-  assert.doesNotMatch(legacyTelemetry, /\bfc-[^\s"]+/);
-  assert.doesNotMatch(legacyTelemetry, /(?:\d{1,3}\.){3}\d{1,3}|::1/);
+    .find((line) => line.includes('[MCP_LEGACY_KEY_PATH]') && line.includes('\"outcome\":\"rejected\"'));
+  assert.ok(rejectedTelemetry, stdout);
+  assert.doesNotMatch(rejectedTelemetry, /\bfc-[^\s"]+/);
+  assert.doesNotMatch(rejectedTelemetry, /(?:\d{1,3}\.){3}\d{1,3}|::1/);
 });

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -381,6 +381,11 @@ async function startFakeFirecrawlBackend(options = {}) {
       res.end(JSON.stringify({ error: 'Unauthorized: Invalid token', success: false }));
       return;
     }
+    if (/Bearer fc-forbidden/.test(req.headers.authorization ?? '')) {
+      res.writeHead(403, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Forbidden', success: false }));
+      return;
+    }
 
     if (req.method === 'POST' && req.url === '/v2/search') {
       if (searchResponse) {
@@ -590,6 +595,11 @@ test('HTTP cloud keyless transport preserves app challenge without advertising O
   assert.equal(searchTool.inputSchema.properties.highlights.type, 'boolean');
   assert.equal('default' in searchTool.inputSchema.properties.highlights, false);
 
+  assert.equal(
+    backend.requests.filter((request) => request.url === '/api/oauth/introspect').length,
+    0,
+    'raw API keys must not be introspected during initialize, tools/list, or tools/call'
+  );
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
 
@@ -662,6 +672,11 @@ test('HTTP cloud transport calls Firecrawl API with authenticated session', asyn
     origin: 'mcp-fastmcp',
     query: 'example domain',
   });
+  assert.equal(
+    fakeApi.requests.filter((request) => request.url === '/api/oauth/introspect').length,
+    0,
+    'raw API keys must reach Core without introspection'
+  );
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
 
@@ -1225,6 +1240,11 @@ test('HTTP cloud transport accepts the x-firecrawl-api-key header', async (t) =>
   const searchCalls = backend.requests.filter((r) => r.url === '/v2/search');
   assert.equal(searchCalls.length, 1);
   assert.equal(searchCalls[0].headers.authorization, 'Bearer fc-header-key');
+  assert.equal(
+    backend.requests.filter((request) => request.url === '/api/oauth/introspect').length,
+    0,
+    'x-firecrawl-api-key must bypass introspection'
+  );
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
 
@@ -1684,8 +1704,16 @@ test('HTTP cloud authenticated Parse forwards ZDR for API-key and managed OAuth 
 
   const uploads = backend.requests.filter((r) => r.url === '/v2/parse/upload-url');
   const parses = backend.requests.filter((r) => r.url === '/v2/parse');
+  const introspectedTokens = backend.requests
+    .filter((request) => request.url === '/api/oauth/introspect')
+    .map((request) => request.body.token);
   assert.equal(uploads.length, 2);
   assert.equal(parses.length, 2);
+  assert.deepEqual(
+    introspectedTokens,
+    ['fco_parse', 'fco_parse'],
+    'only OAuth access tokens may be introspected on the account route'
+  );
   assert.equal(uploads[0].headers.authorization, 'Bearer fc-parse-api-key');
   assert.equal(parses[0].headers.authorization, 'Bearer fc-parse-api-key');
   for (const request of [uploads[1], parses[1]]) {
@@ -1825,6 +1853,11 @@ test('account endpoint challenges anonymous clients and accepts API keys', async
   );
   assert.ok(names.includes('firecrawl_crawl'));
   assert.ok(names.length > 3);
+  assert.equal(
+    backend.requests.filter((request) => request.url === '/api/oauth/introspect').length,
+    0,
+    'the account route must not introspect raw API keys'
+  );
 });
 
 test('account endpoint keeps OAuth discovery and gives safe re-auth guidance for inactive OAuth', async (t) => {
@@ -1945,68 +1978,17 @@ test('credential validation outages do not misdirect clients into OAuth', async 
   assert.equal(typeof oauthRecord.elapsed_ms, 'number');
   assert.doesNotMatch(stderr, /fco_account_token/);
 
-  // An API key is enriched by introspection, not authorized by it, so the same
-  // outage costs it the enrichment and nothing else. The record is still
-  // emitted, so a failing dependency stays visible while users are unaffected.
+  // An API key never needs the issuer, so the same outage does not reach it.
   stderr = '';
   const apiKey = await listTools('fc-account-key');
   assert.equal(apiKey.status, 200);
   assert.match(await apiKey.text(), /firecrawl_scrape/);
-  const keyRecord = await waitForCredentialValidationLog(() => stderr);
-  assert.ok(keyRecord, `missing validation log in ${stderr}`);
-  assert.equal(keyRecord.reason, 'introspect_transport_error');
-  assert.equal(keyRecord.introspect_status, null);
-  assert.equal(keyRecord.aborted, false);
-  assert.equal(keyRecord.resource, ACCOUNT_RESOURCE);
-  assert.equal(typeof keyRecord.elapsed_ms, 'number');
-  assert.doesNotMatch(stderr, /fc-account-key/);
+  await delay(150);
+  assert.doesNotMatch(stderr, /\[MCP_CREDENTIAL_VALIDATION\]/);
 });
 
-test('an unusable key still gets recovery when introspection cannot answer', async (t) => {
+test('an invalid API key gets recovery from Core without introspection', async (t) => {
   const backend = await startFakeFirecrawlBackend();
-  t.after(() => backend.close());
-  const unreachableIssuerPort = await getFreePort();
-  const port = await getFreePort();
-  const child = spawnServer({
-    CLOUD_SERVICE: 'true',
-    FASTMCP_ENDPOINT: '/v2/mcp',
-    FIRECRAWL_API_URL: backend.url,
-    FIRECRAWL_OAUTH_ISSUER: `http://127.0.0.1:${unreachableIssuerPort}`,
-    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
-    HTTP_STREAMABLE_SERVER: 'true',
-    PORT: String(port),
-  });
-  t.after(() => stopChild(child));
-  await waitForHealth(port, child);
-
-  // Introspection is unreachable, so the key reaches Core unresolved and Core
-  // supplies the verdict. The agent must still receive guidance it can act on
-  // rather than a raw upstream error.
-  const call = await httpToolCall(port, {
-    headers: { authorization: 'Bearer fc-invalid' },
-    id: 1,
-    params: { arguments: { query: 'x' }, name: 'firecrawl_search' },
-  });
-  assert.equal(call.status, 200);
-  const result = parseSseJson(await call.text()).result;
-  assert.equal(result.isError, true);
-  assert.equal(result.content[0].text, INVALID_API_KEY_MESSAGE);
-  assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID');
-  assert.equal(result.structuredContent.message, INVALID_API_KEY_MESSAGE);
-});
-
-test('an API key survives an active introspection answer it cannot use', async (t) => {
-  // The answer is well formed enough to parse but carries no usable scope, so
-  // introspectToken raises introspect_unusable_credential. That is a statement
-  // about the answer, not about the key, so Core still gets to decide.
-  const backend = await startFakeFirecrawlBackend({
-    introspectionHandler: () => ({
-      active: true,
-      api_key: 'fc-account-key',
-      credential_purpose: 'general',
-      scope: '',
-    }),
-  });
   t.after(() => backend.close());
   const port = await getFreePort();
   const child = spawnServer({
@@ -2021,31 +2003,45 @@ test('an API key survives an active introspection answer it cannot use', async (
   t.after(() => stopChild(child));
   await waitForHealth(port, child);
 
-  const response = await fetch(`http://127.0.0.1:${port}/v2/mcp`, {
-    body: JSON.stringify({ id: 1, jsonrpc: '2.0', method: 'tools/list', params: {} }),
-    headers: {
-      accept: 'application/json, text/event-stream',
-      authorization: 'Bearer fc-account-key',
-      'content-type': 'application/json',
-    },
-    method: 'POST',
+  const call = await httpToolCall(port, {
+    headers: { authorization: 'Bearer fc-invalid' },
+    id: 1,
+    params: { arguments: { query: 'x' }, name: 'firecrawl_search' },
   });
-  assert.equal(response.status, 200);
-  assert.match(await response.text(), /firecrawl_scrape/);
+  assert.equal(call.status, 200);
+  const result = parseSseJson(await call.text()).result;
+  assert.equal(result.isError, true);
+  assert.equal(result.content[0].text, INVALID_API_KEY_MESSAGE);
+  assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID');
+  assert.equal(result.structuredContent.message, INVALID_API_KEY_MESSAGE);
+  assert.equal(
+    backend.requests.filter((request) => request.url === '/api/oauth/introspect').length,
+    0,
+    'Core, not introspection, must decide whether a raw API key is valid'
+  );
+  assert.equal(backend.requests.some((request) => request.url === '/v2/search'), true);
+
+  const forbiddenCall = await httpToolCall(port, {
+    headers: { authorization: 'Bearer fc-forbidden' },
+    id: 2,
+    params: { arguments: { query: 'x' }, name: 'firecrawl_search' },
+  });
+  assert.equal(forbiddenCall.status, 200);
+  const forbiddenResult = parseSseJson(await forbiddenCall.text()).result;
+  assert.equal(forbiddenResult.isError, true);
+  assert.notEqual(forbiddenResult.content[0].text, INVALID_API_KEY_MESSAGE);
+  assert.notEqual(forbiddenResult.structuredContent?.code, 'CREDENTIAL_INVALID');
 });
 
-test('a fetch-based tool maps a Core rejection to recovery like the SDK tools do', async (t) => {
-  // firecrawl_parse reaches Core through plain fetch rather than the SDK, so it
-  // exercises the path that reports its status through CoreHttpError.
+test('feedback tools map a Core 401 to API-key recovery without introspection', async (t) => {
   const backend = await startFakeFirecrawlBackend();
   t.after(() => backend.close());
-  const unreachableIssuerPort = await getFreePort();
   const port = await getFreePort();
   const child = spawnServer({
     CLOUD_SERVICE: 'true',
     FASTMCP_ENDPOINT: '/v2/mcp',
     FIRECRAWL_API_URL: backend.url,
-    FIRECRAWL_OAUTH_ISSUER: `http://127.0.0.1:${unreachableIssuerPort}`,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
     FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
     HTTP_STREAMABLE_SERVER: 'true',
     PORT: String(port),
@@ -2053,10 +2049,69 @@ test('a fetch-based tool maps a Core rejection to recovery like the SDK tools do
   t.after(() => stopChild(child));
   await waitForHealth(port, child);
 
-  const call = await httpToolCall(port, {
-    headers: { authorization: 'Bearer fc-invalid' },
-    id: 1,
-    params: {
+  const cases = [
+    {
+      arguments: {
+        querySuggestions: 'Use a narrower query',
+        rating: 'bad',
+        searchId: '00000000-0000-4000-8000-000000000001',
+      },
+      name: 'firecrawl_search_feedback',
+      path: '/v2/search/00000000-0000-4000-8000-000000000001/feedback',
+    },
+    {
+      arguments: {
+        endpoint: 'search',
+        jobId: '00000000-0000-4000-8000-000000000002',
+        rating: 'bad',
+      },
+      name: 'firecrawl_feedback',
+      path: '/v2/feedback',
+    },
+  ];
+
+  for (const testCase of cases) {
+    const call = await httpToolCall(port, {
+      headers: { authorization: 'Bearer fc-invalid' },
+      id: testCase.name,
+      params: { arguments: testCase.arguments, name: testCase.name },
+    });
+    assert.equal(call.status, 200, testCase.name);
+    const result = parseSseJson(await call.text()).result;
+    assert.equal(result.isError, true, testCase.name);
+    assert.equal(result.content[0].text, INVALID_API_KEY_MESSAGE, testCase.name);
+    assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID', testCase.name);
+    assert.equal(
+      backend.requests.some((request) => request.url === testCase.path),
+      true,
+      testCase.name
+    );
+  }
+
+  assert.equal(
+    backend.requests.filter((request) => request.url === '/api/oauth/introspect').length,
+    0
+  );
+});
+
+test('fetch-based tools map a Core rejection to recovery like SDK tools do', async (t) => {
+  const backend = await startFakeFirecrawlBackend();
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const cases = [
+    {
       arguments: {
         contentType: 'application/pdf',
         filePath: '/not-read-by-hosted-mcp/document.pdf',
@@ -2065,15 +2120,29 @@ test('a fetch-based tool maps a Core rejection to recovery like the SDK tools do
       },
       name: 'firecrawl_parse',
     },
-  });
-  assert.equal(call.status, 200);
-  const result = parseSseJson(await call.text()).result;
-  assert.equal(result.isError, true);
-  assert.equal(result.content[0].text, INVALID_API_KEY_MESSAGE);
-  assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID');
+    { arguments: {}, name: 'firecrawl_monitor_list' },
+  ];
+
+  for (const testCase of cases) {
+    const call = await httpToolCall(port, {
+      headers: { authorization: 'Bearer fc-invalid' },
+      id: testCase.name,
+      params: { arguments: testCase.arguments, name: testCase.name },
+    });
+    assert.equal(call.status, 200, testCase.name);
+    const result = parseSseJson(await call.text()).result;
+    assert.equal(result.isError, true, testCase.name);
+    assert.equal(result.content[0].text, INVALID_API_KEY_MESSAGE, testCase.name);
+    assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID', testCase.name);
+  }
+
+  assert.equal(
+    backend.requests.filter((request) => request.url === '/api/oauth/introspect').length,
+    0
+  );
 });
 
-test('an OAuth session keeps its own guidance when Core rejects the credential', async (t) => {
+test('an OAuth session keeps its existing Core 401 behavior', async (t) => {
   // The API-key recovery says to replace a key on this server, which is the
   // wrong instruction for a session that authenticated by connecting an
   // account. Only a session that forwarded an unresolved key should get it.
@@ -2109,6 +2178,30 @@ test('an OAuth session keeps its own guidance when Core rejects the credential',
   assert.equal(result.isError, true);
   assert.notEqual(result.content[0].text, INVALID_API_KEY_MESSAGE);
   assert.notEqual(result.structuredContent?.code, 'CREDENTIAL_INVALID');
+
+  // Feedback tools intentionally return non-API-key 4xx responses as data so
+  // agents do not retry terminal feedback rejections.
+  const feedbackCall = await httpToolCall(port, {
+    headers: { authorization: 'Bearer fco_resolved_token' },
+    id: 2,
+    params: {
+      arguments: {
+        endpoint: 'search',
+        jobId: '00000000-0000-4000-8000-000000000003',
+        rating: 'bad',
+      },
+      name: 'firecrawl_feedback',
+    },
+  });
+  assert.equal(feedbackCall.status, 200);
+  const feedbackResult = parseSseJson(await feedbackCall.text()).result;
+  assert.notEqual(feedbackResult.isError, true);
+  assert.deepEqual(JSON.parse(feedbackResult.content[0].text), {
+    error: 'Unauthorized: Invalid token',
+    retryable: false,
+    status: 401,
+    success: false,
+  });
 });
 
 test('active introspection with an unknown credential purpose fails closed', async (t) => {
@@ -2601,11 +2694,9 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
   });
   assert.equal(replay.status, 401);
 
-  // On the keyless+API-key endpoint an invalid key is now agent-legible: the
-  // session connects (200) and lists tools, so an MCP client (which commonly
-  // stops after a 401 at tools/list) proceeds; any tool call then returns the
-  // CREDENTIAL_INVALID recovery payload as a 200 isError result. A raw 401 with
-  // the payload in the body was unreachable to the model.
+  // A well-formed API key is admitted because only Core can decide whether it
+  // is valid. The session lists tools, then a Core 401 becomes an agent-legible
+  // CREDENTIAL_INVALID result instead of an unreachable transport 401.
   const invalidList = await fetch(`http://127.0.0.1:${port}/v2/mcp`, {
     body: JSON.stringify({ id: 2, jsonrpc: '2.0', method: 'tools/list', params: {} }),
     headers: {
@@ -2643,9 +2734,8 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
   assert.doesNotMatch(invalidRecovery.message, /never ask/i);
   assert.doesNotMatch(invalidRecovery.message, /outside this chat/i);
   assert.doesNotMatch(invalidRecovery.message, /Authorization: Bearer/);
-  // No tool is actually callable in a credentialError session (the
-  // credentialError check gates execute() before the keyless branch), so the
-  // payload must not advertise keyless tools as available.
+  // The rejected credential cannot call any tool, so the recovery payload must
+  // not advertise keyless tools as available.
   assert.equal(
     invalidRecovery.available_tools,
     undefined,
@@ -2666,10 +2756,17 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
   const invalidLegacyJson = parseSseJson(await invalidLegacyPath.text());
   assert.ok((invalidLegacyJson.result?.tools?.length ?? 0) > 0);
   await delay(25);
-  const rejectedTelemetry = stdout
+  // A well-formed API key is admitted at connect time because Core owns the
+  // verdict. The legacy-path record must still contain no credential material.
+  const legacyTelemetry = stdout
     .split(/\r?\n/)
-    .find((line) => line.includes('[MCP_LEGACY_KEY_PATH]') && line.includes('\"outcome\":\"rejected\"'));
-  assert.ok(rejectedTelemetry, stdout);
-  assert.doesNotMatch(rejectedTelemetry, /\bfc-[^\s"]+/);
-  assert.doesNotMatch(rejectedTelemetry, /(?:\d{1,3}\.){3}\d{1,3}|::1/);
+    .find((line) => line.includes('[MCP_LEGACY_KEY_PATH]'));
+  assert.ok(legacyTelemetry, stdout);
+  assert.match(legacyTelemetry, /"outcome":"accepted"/);
+  assert.doesNotMatch(legacyTelemetry, /\bfc-[^\s"]+/);
+  assert.doesNotMatch(legacyTelemetry, /(?:\d{1,3}\.){3}\d{1,3}|::1/);
+  const introspectedTokens = backend.requests
+    .filter((request) => request.url === '/api/oauth/introspect')
+    .map((request) => request.body.token);
+  assert.deepEqual(introspectedTokens, ['fco_account']);
 });

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -372,6 +372,14 @@ async function startFakeFirecrawlBackend(options = {}) {
       return;
     }
 
+    // Core is the authority on a forwarded API key, so the suite's invalid keys
+    // are rejected here rather than at introspection.
+    if ((req.headers.authorization ?? '').includes('invalid')) {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Unauthorized: Invalid token', success: false }));
+      return;
+    }
+
     if (req.method === 'POST' && req.url === '/v2/search') {
       if (searchResponse) {
         res.writeHead(searchResponse.status, { 'content-type': 'application/json' });
@@ -1909,9 +1917,8 @@ test('credential validation outages do not misdirect clients into OAuth', async 
   });
   await waitForHealth(port, child);
 
-  for (const token of ['fc-account-key', 'fco_account_token']) {
-    stderr = '';
-    const response = await fetch(`http://127.0.0.1:${port}/v2/mcp-oauth`, {
+  const listTools = (token) =>
+    fetch(`http://127.0.0.1:${port}/v2/mcp-oauth`, {
       body: JSON.stringify({ id: token, jsonrpc: '2.0', method: 'tools/list', params: {} }),
       headers: {
         accept: 'application/json, text/event-stream',
@@ -1920,18 +1927,30 @@ test('credential validation outages do not misdirect clients into OAuth', async 
       },
       method: 'POST',
     });
-    await assertCredentialValidationUnavailable(response, token);
 
-    // An unreachable issuer is a transport fault, not the abort budget firing.
-    const record = await waitForCredentialValidationLog(() => stderr);
-    assert.ok(record, `${token}: missing validation log in ${stderr}`);
-    assert.equal(record.reason, 'introspect_transport_error', token);
-    assert.equal(record.introspect_status, null, token);
-    assert.equal(record.aborted, false, token);
-    assert.equal(record.resource, ACCOUNT_RESOURCE, token);
-    assert.equal(typeof record.elapsed_ms, 'number', token);
-    assert.doesNotMatch(stderr, new RegExp(token), token);
-  }
+  // An OAuth access token cannot be resolved without the issuer, so it still
+  // fails closed.
+  stderr = '';
+  const oauth = await listTools('fco_account_token');
+  await assertCredentialValidationUnavailable(oauth, 'fco_account_token');
+
+  // An unreachable issuer is a transport fault, not the abort budget firing.
+  const record = await waitForCredentialValidationLog(() => stderr);
+  assert.ok(record, `missing validation log in ${stderr}`);
+  assert.equal(record.reason, 'introspect_transport_error');
+  assert.equal(record.introspect_status, null);
+  assert.equal(record.aborted, false);
+  assert.equal(record.resource, ACCOUNT_RESOURCE);
+  assert.equal(typeof record.elapsed_ms, 'number');
+  assert.doesNotMatch(stderr, /fco_account_token/);
+
+  // An API key never needed the issuer, so the same outage does not reach it.
+  stderr = '';
+  const apiKey = await listTools('fc-account-key');
+  assert.equal(apiKey.status, 200);
+  assert.match(await apiKey.text(), /firecrawl_scrape/);
+  await delay(150);
+  assert.doesNotMatch(stderr, /\[MCP_CREDENTIAL_VALIDATION\]/);
 });
 
 test('active introspection with an unknown credential purpose fails closed', async (t) => {
@@ -2489,10 +2508,14 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
   const invalidLegacyJson = parseSseJson(await invalidLegacyPath.text());
   assert.ok((invalidLegacyJson.result?.tools?.length ?? 0) > 0);
   await delay(25);
-  const rejectedTelemetry = stdout
+  // A well-formed API key is admitted at connect time now that Core owns the
+  // verdict, so the legacy-path record reports accepted and the correction is
+  // delivered by the tool call above. The record must still name no credential.
+  const legacyTelemetry = stdout
     .split(/\r?\n/)
-    .find((line) => line.includes('[MCP_LEGACY_KEY_PATH]') && line.includes('\"outcome\":\"rejected\"'));
-  assert.ok(rejectedTelemetry, stdout);
-  assert.doesNotMatch(rejectedTelemetry, /\bfc-[^\s"]+/);
-  assert.doesNotMatch(rejectedTelemetry, /(?:\d{1,3}\.){3}\d{1,3}|::1/);
+    .find((line) => line.includes('[MCP_LEGACY_KEY_PATH]'));
+  assert.ok(legacyTelemetry, stdout);
+  assert.match(legacyTelemetry, /"outcome":"accepted"/);
+  assert.doesNotMatch(legacyTelemetry, /\bfc-[^\s"]+/);
+  assert.doesNotMatch(legacyTelemetry, /(?:\d{1,3}\.){3}\d{1,3}|::1/);
 });


### PR DESCRIPTION
## Why

A raw `fc-` API key is already the credential Core authenticates. Resolving it through `/api/oauth/introspect` returns the same key while making every authenticated MCP request depend on the authorization service.

Raw API keys should therefore make zero introspection calls. OAuth access tokens still require strict introspection because Core cannot resolve an `fco_` token directly.

## Summary

- Return raw `fc-` credentials unchanged from the shared credential resolver. This covers `/v2/mcp`, `/v2/mcp-oauth`, and the API-key-compatible `/v2/mcp-search` companion.
- Reject `fc-` credentials locally on OAuth-only search profiles, before introspection.
- Keep strict, route-specific `fco_` introspection, audience validation, credential-purpose validation, and fail-closed behavior.
- Translate an exact Core 401 into `CREDENTIAL_INVALID` only for API-key sessions. SDK, parse, monitor, and feedback paths preserve the upstream status needed by the shared recovery boundary.
- Preserve Core 403 responses and existing non-API-key feedback behavior.
- Preserve API-key provenance on local HTTP headers so Core 401 recovery applies there without changing environment-backed or stdio credential behavior.

Without API-key introspection, API-key sessions no longer receive account metadata from the authorization service. Console action records continue, but account-scoped action-log submission is skipped because `team_id` is absent.

Deployment note: this change relies on Core's existing purpose-aware API-key authentication. Confirm the corresponding Core and database rollout before deploying this MCP revision.

## Test Plan

- `npm test` (82 tests)
- `npm run lint`
- `npx tsc --noEmit`

Regression coverage verifies:

- zero API-key introspection during `initialize`, `tools/list`, and tool calls
- zero API-key introspection on `/v2/mcp`, `/v2/mcp-oauth`, API-key-compatible search, and OAuth-only search
- API-key header and bearer transports
- unchanged forwarding of raw API keys to Core
- strict `fco_` introspection and route-specific audience checks
- Core 401 recovery across SDK, parse, monitor, and both feedback paths
- Core 403 and non-API-key feedback responses are not rewritten as invalid API keys
