### PR TITLE
Reject unknown arguments on firecrawl_developer_search

### DIFF
--- a/src/developer.ts
+++ b/src/developer.ts
@@ -92,7 +92,13 @@ For a developer question — code behaviour, a library or framework, an API cont
 
 Returns ranked results with an ID, source type, URL, title, and the matched passages in markdown.
 `,
-    parameters: z.object({
+    // strictObject so unknown argument keys are rejected at parse time with
+    // the same -32602 the value constraints already raise. The published JSON
+    // schema has always advertised additionalProperties: false; plain z.object
+    // silently stripped unknown keys, so a misrouted or hallucinated argument
+    // (limit, passages, a typo) returned plausible results instead of an
+    // error. Firebrain finding F8, 2026-08-03 Developer Index audit.
+    parameters: z.strictObject({
       query: z
         .string()
         .min(1)

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1146,6 +1146,57 @@ test('developer search serves server-shaped passages uncapped', async (t) => {
   );
 });
 
+test('developer search rejects unknown arguments before calling the API', async (t) => {
+  const fakeApi = await startFakeDeveloperApi();
+  t.after(() => fakeApi.close());
+
+  const child = spawnServer({
+    FIRECRAWL_API_KEY: 'fc-test',
+    FIRECRAWL_API_URL: fakeApi.url,
+  });
+  t.after(() => stopChild(child));
+
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'firecrawl-developer-strict', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+
+  // The published schema declares additionalProperties: false; the runtime
+  // must enforce it. A misrouted parameter (limit belongs to other tools) and
+  // an invented one must fail loudly, not return plausible results.
+  const tools = await client.request('tools/list');
+  const developerTool = tools.tools.find(
+    (tool) => tool.name === 'firecrawl_developer_search'
+  );
+  assert.ok(developerTool);
+  assert.equal(developerTool.inputSchema.additionalProperties, false);
+
+  await assert.rejects(
+    client.request('tools/call', {
+      arguments: { bogusParam: 'xyz', limit: 5, query: 'python asyncio' },
+      name: 'firecrawl_developer_search',
+    }),
+    /-32602/
+  );
+
+  // Rejection happens at argument parse time: the API must never be reached.
+  assert.equal(fakeApi.requests.length, 0);
+
+  // Known arguments still pass through untouched.
+  const ok = await client.request('tools/call', {
+    arguments: { k: 2, query: 'server budget' },
+    name: 'firecrawl_developer_search',
+  });
+  assert.notEqual(ok.isError, true);
+  assert.deepEqual(
+    fakeApi.requests.map((request) => request.url),
+    ['/v2/search/developer?query=server+budget&k=2']
+  );
+});
+
 test('stdio transport calls Firecrawl API through a tool end to end', async (t) => {
   const fakeApi = await startFakeFirecrawlApi();
   t.after(() => fakeApi.close());


### PR DESCRIPTION
## Why

`firecrawl_developer_search` publishes a JSON schema with `additionalProperties: false`, but the runtime parses arguments with plain `z.object`, which strips unknown keys instead of rejecting them. A call carrying a misrouted parameter (`limit`) and an invented one (`bogusParam`) returns HTTP 200 with full plausible results, while a value violation like `k: 0` raises `-32602`. The mixed behavior is the dangerous part: a caller who sees `k: 0` rejected reasonably concludes the whole schema is enforced, and a typo in an integration or a benchmark sweep then fails completely silently.

This is finding F8 from the 2026-08-03 Developer Index pre-launch audit (Firebrain task `devindex-unknown-params-silently-dropped`). Re-verified today against the hosted `firecrawl-fastmcp` 3.24.1: `{"query":"python asyncio","limit":5,"bogusParam":"xyz"}` still returns 200 with ~15k chars of results, and `tools/list` still advertises `additionalProperties: false`. The raw API fixed its half long ago: the same body against `POST /v2/search/developer` returns 400 naming both unrecognized keys.

## What

- `src/developer.ts`: `z.object` becomes `z.strictObject` on the tool parameters. Unknown keys now raise the same `-32602` the value constraints already do, at parse time, before any upstream call. The emitted JSON schema is unchanged (`additionalProperties: false` either way), so the published contract finally matches the runtime.
- `tests/mcp-smoke.test.mjs`: regression test spawns the stdio server against the fake developer API and pins three things: the unknown-key call rejects with `-32602`, the fake API records zero requests for it, and a well-formed call still passes through with only declared arguments.

## Scope

Deliberately limited to the tool the audit measured. Most other tools in `src/index.ts` share the same plain `z.object` pattern; flipping all of them to strict changes error ergonomics for every agent caller and deserves its own decision rather than a ride-along. Happy to follow up with the sweep if that is the direction you want.

Plays fine with #379: that PR freezes this tool's argument list and pins `additionalProperties: false` in a contract test, which is exactly the contract this PR makes the runtime honor. `z.strictObject` serializes identically, so the frozen contract test stays green; whichever lands second has a one-line rebase on the `parameters:` line.

## Test plan

- `npm test`: the two developer-search tests pass (`developer search serves server-shaped passages uncapped`, `developer search rejects unknown arguments before calling the API`), 82 of 85 pass overall.
- The three failures (`HTTP cloud keyless transport preserves app challenge without advertising OAuth`, `stdio transport initializes and lists Firecrawl tools`, `account endpoint accepts legacy OAuth one way and delegates managed keys`) fail identically on clean `main` in the same environment, so they are pre-existing and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `firecrawl_developer_search` reject unknown argument keys at parse time instead of silently stripping them, so calls with misrouted or invented parameters now raise `-32602` before any API call. The new behavior matches the published JSON schema, which already declares `additionalProperties: false`.

- Switches the tool's parameter schema from `z.object` to `z.strictObject`; the emitted schema is unchanged.
- Adds a regression test pinning the `-32602` rejection, confirming the API receives zero requests for invalid calls, and verifying well-formed calls pass through untouched.
- Addresses Firebrain finding F8 (`devindex-unknown-params-silently-dropped`) from the 2026-08-03 Developer Index audit.
- Scope is limited to this tool only; other tools sharing the plain `z.object` pattern are left as-is.

<sup>Written for commit cc907ae280dd0dd4f85964cedbc94b09f9414b1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

