### PR TITLE
fix(search): forward documented request fields

### DIFF
--- a/docs/search-profile.md
+++ b/docs/search-profile.md
@@ -37,8 +37,9 @@ same index beside ordinary web results. Both are available here.
 The search surface's `firecrawl_search` takes **no `scrapeOptions`**. Its input
 schema is strict (unknown fields are rejected), and its executor builds the
 outbound `/v2/search` body from an explicit list of allowed fields
-(`query`, `limit`, `tbs`, `filter`, `location`, `sources`, `categories`,
-`highlights`, `enterprise`) plus `origin`. It never spreads raw arguments, so
+(`query`, `limit`, `tbs`, `filter`, `location`, `country`, `sources`,
+`categories`, `timeout`, `ignoreInvalidURLs`, `highlights`, `enterprise`) plus
+`origin`. It never spreads raw arguments, so
 no request from this surface can ask the API to fetch third-party page content.
 The schema and body construction enforce this directly, and contract tests guard
 the behavior. No runtime filter is involved.

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { registerDeveloperTools } from './developer';
 import { extractSingleTrustedClientIp } from './keyless-client-ip';
 import { registerMonitorTools } from './monitor';
 import { registerResearchTools } from './research';
+import { searchHttpOptions } from './search-http-options';
 import { escapeWWWAuthenticateValue } from './www-authenticate';
 import {
   credentialForOutboundRequest,
@@ -2268,7 +2269,11 @@ Each web result is a title, URL, and description, not the page. Add \`scrapeOpti
     // high-level `search()` helper strips `id` and `creditsUsed`, which
     // supports the optional authenticated `firecrawl_search_feedback` workflow.
     const client = getClient(session);
-    const httpRes = await (client as any).http.post('/v2/search', searchBody);
+    const httpRes = await (client as any).http.post(
+      '/v2/search',
+      searchBody,
+      searchHttpOptions(searchOpts.timeout as number | undefined)
+    );
     return asText(httpRes?.data ?? {});
   },
 });
@@ -3314,7 +3319,11 @@ Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`.
 
       log.info('Searching', { query: searchQuery });
       const client = getClientFn(session);
-      const httpRes = await (client as any).http.post('/v2/search', searchBody);
+      const httpRes = await (client as any).http.post(
+        '/v2/search',
+        searchBody,
+        searchHttpOptions(timeout)
+      );
       return asText(httpRes?.data ?? {});
     },
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { registerDeveloperTools } from './developer';
 import { extractSingleTrustedClientIp } from './keyless-client-ip';
 import { registerMonitorTools } from './monitor';
 import { registerResearchTools } from './research';
-import { searchHttpOptions } from './search-http-options';
+import { postSearch } from './search-http-options';
 import { escapeWWWAuthenticateValue } from './www-authenticate';
 import {
   credentialForOutboundRequest,
@@ -2269,11 +2269,7 @@ Each web result is a title, URL, and description, not the page. Add \`scrapeOpti
     // high-level `search()` helper strips `id` and `creditsUsed`, which
     // supports the optional authenticated `firecrawl_search_feedback` workflow.
     const client = getClient(session);
-    const httpRes = await (client as any).http.post(
-      '/v2/search',
-      searchBody,
-      searchHttpOptions(searchOpts.timeout as number | undefined)
-    );
+    const httpRes = await postSearch((client as any).http, searchBody);
     return asText(httpRes?.data ?? {});
   },
 });
@@ -3319,11 +3315,7 @@ Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`.
 
       log.info('Searching', { query: searchQuery });
       const client = getClientFn(session);
-      const httpRes = await (client as any).http.post(
-        '/v2/search',
-        searchBody,
-        searchHttpOptions(timeout)
-      );
+      const httpRes = await postSearch((client as any).http, searchBody);
       return asText(httpRes?.data ?? {});
     },
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -892,6 +892,24 @@ const searchToolBaseFields = {
   tbs: z.string().optional(),
   filter: z.string().optional(),
   location: z.string().optional(),
+  country: z
+    .string()
+    .optional()
+    .describe(
+      'ISO country code for geo-targeting search results (for example, `US` or `DE`). For best results, set `location` as well.'
+    ),
+  timeout: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Server-side search timeout in milliseconds.'),
+  ignoreInvalidURLs: z
+    .boolean()
+    .optional()
+    .describe(
+      'Exclude URLs that are invalid for other Firecrawl endpoints, which is useful when feeding search results into another tool.'
+    ),
   includeDomains: z.array(searchDomainSchema).optional(),
   excludeDomains: z.array(searchDomainSchema).optional(),
   sources: z
@@ -3244,6 +3262,9 @@ Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`.
         tbs,
         filter,
         location,
+        country,
+        timeout,
+        ignoreInvalidURLs,
         sources,
         categories,
         highlights,
@@ -3256,6 +3277,9 @@ Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`.
         tbs?: string;
         filter?: string;
         location?: string;
+        country?: string;
+        timeout?: number;
+        ignoreInvalidURLs?: boolean;
         sources?: Array<{ type: string }>;
         categories?: string[];
         highlights?: boolean;
@@ -3277,6 +3301,9 @@ Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`.
           tbs,
           filter,
           location,
+          country,
+          timeout,
+          ignoreInvalidURLs,
           sources,
           categories,
           highlights,

--- a/src/search-http-options.ts
+++ b/src/search-http-options.ts
@@ -1,0 +1,7 @@
+const SEARCH_TRANSPORT_MARGIN_MS = 5_000;
+
+export function searchHttpOptions(timeout?: number) {
+  return typeof timeout === 'number'
+    ? { timeoutMs: timeout + SEARCH_TRANSPORT_MARGIN_MS }
+    : {};
+}

--- a/src/search-http-options.ts
+++ b/src/search-http-options.ts
@@ -1,7 +1,27 @@
 const SEARCH_TRANSPORT_MARGIN_MS = 5_000;
 
-export function searchHttpOptions(timeout?: number) {
+type SearchHttpTransport = {
+  post(
+    endpoint: string,
+    body: Record<string, unknown>,
+    options?: { timeoutMs?: number }
+  ): Promise<{ data?: unknown }>;
+};
+
+function searchHttpOptions(timeout?: number) {
   return typeof timeout === 'number'
     ? { timeoutMs: timeout + SEARCH_TRANSPORT_MARGIN_MS }
     : {};
+}
+
+export function postSearch(
+  http: SearchHttpTransport,
+  body: Record<string, unknown>
+) {
+  const timeout = body.timeout;
+  return http.post(
+    '/v2/search',
+    body,
+    searchHttpOptions(typeof timeout === 'number' ? timeout : undefined)
+  );
 }

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -427,9 +427,12 @@ test('search firecrawl_search sends a clean body built from allowed fields only'
     method: 'tools/call',
     params: {
       arguments: {
+        country: 'DE',
+        ignoreInvalidURLs: true,
         query: 'example domain',
         limit: 1,
         sources: [{ type: 'web' }],
+        timeout: 30000,
       },
       name: 'firecrawl_search',
     },
@@ -450,6 +453,9 @@ test('search firecrawl_search sends a clean body built from allowed fields only'
     'tbs',
     'filter',
     'location',
+    'country',
+    'timeout',
+    'ignoreInvalidURLs',
     'sources',
     'categories',
     'highlights',
@@ -460,9 +466,12 @@ test('search firecrawl_search sends a clean body built from allowed fields only'
     assert.equal(allowedKeys.has(key), true, `unexpected outbound field: ${key}`);
   }
   assert.deepEqual(sentBody, {
+    country: 'DE',
+    ignoreInvalidURLs: true,
     query: 'example domain',
     limit: 1,
     sources: [{ type: 'web' }],
+    timeout: 30000,
     origin: 'mcp-fastmcp',
   });
 });

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -634,6 +634,9 @@ test('HTTP cloud keyless transport preserves app challenge without advertising O
   assert.equal(searchTool.inputSchema.properties.limit.type, 'integer');
   assert.equal(searchTool.inputSchema.properties.limit.minimum, 1);
   assert.equal(searchTool.inputSchema.properties.limit.maximum, 100);
+  assert.equal(searchTool.inputSchema.properties.country.type, 'string');
+  assert.equal(searchTool.inputSchema.properties.timeout.type, 'integer');
+  assert.equal(searchTool.inputSchema.properties.ignoreInvalidURLs.type, 'boolean');
 
   assert.equal(
     backend.requests.filter((request) => request.url === '/api/oauth/introspect').length,
@@ -671,7 +674,14 @@ test('HTTP cloud transport calls Firecrawl API with authenticated session', asyn
       jsonrpc: '2.0',
       method: 'tools/call',
       params: {
-        arguments: { highlights: false, limit: 1, query: 'example domain' },
+        arguments: {
+          country: 'DE',
+          highlights: false,
+          ignoreInvalidURLs: true,
+          limit: 1,
+          query: 'example domain',
+          timeout: 30000,
+        },
         name: 'firecrawl_search',
       },
     }),
@@ -707,10 +717,13 @@ test('HTTP cloud transport calls Firecrawl API with authenticated session', asyn
   assert.equal(searchRequest.method, 'POST');
   assert.equal(searchRequest.headers.authorization, 'Bearer fc-http-test');
   assert.deepEqual(searchRequest.body, {
+    country: 'DE',
     highlights: false,
+    ignoreInvalidURLs: true,
     limit: 1,
     origin: 'mcp-fastmcp',
     query: 'example domain',
+    timeout: 30000,
   });
   assert.equal(
     fakeApi.requests.filter((request) => request.url === '/api/oauth/introspect').length,

--- a/tests/search-http-options.test.mjs
+++ b/tests/search-http-options.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { searchHttpOptions } from '../src/search-http-options.ts';
+
+test('search transport outlives the requested API timeout', () => {
+  assert.deepEqual(searchHttpOptions(300_000), { timeoutMs: 305_000 });
+});
+
+test('search transport keeps the SDK default when no API timeout is requested', () => {
+  assert.deepEqual(searchHttpOptions(), {});
+});

--- a/tests/search-http-options.test.mjs
+++ b/tests/search-http-options.test.mjs
@@ -1,12 +1,38 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { searchHttpOptions } from '../src/search-http-options.ts';
+import { postSearch } from '../src/search-http-options.ts';
 
-test('search transport outlives the requested API timeout', () => {
-  assert.deepEqual(searchHttpOptions(300_000), { timeoutMs: 305_000 });
+function recordingTransport() {
+  const calls = [];
+  return {
+    calls,
+    http: {
+      async post(...args) {
+        calls.push(args);
+        return { data: { success: true } };
+      },
+    },
+  };
+}
+
+test('search transport forwards the body and outlives the API timeout', async () => {
+  const { calls, http } = recordingTransport();
+  const body = { query: 'example domain', timeout: 300_000 };
+
+  const response = await postSearch(http, body);
+
+  assert.deepEqual(response, { data: { success: true } });
+  assert.deepEqual(calls, [
+    ['/v2/search', body, { timeoutMs: 305_000 }],
+  ]);
 });
 
-test('search transport keeps the SDK default when no API timeout is requested', () => {
-  assert.deepEqual(searchHttpOptions(), {});
+test('search transport keeps the SDK default when no API timeout is requested', async () => {
+  const { calls, http } = recordingTransport();
+  const body = { query: 'example domain' };
+
+  await postSearch(http, body);
+
+  assert.deepEqual(calls, [['/v2/search', body, {}]]);
 });


### PR DESCRIPTION
## Summary

- expose the documented `country`, `timeout`, and `ignoreInvalidURLs` inputs on both `firecrawl_search` surfaces
- forward those inputs to `/v2/search`, including through the strict search-only allowlist
- cover the published schema and both outbound request paths with regression assertions

The original issue also requested `categories`; current `main` already supports and forwards that field, so this change addresses the three fields that remain missing.

## Validation

- `pnpm test` — 84 passed
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `git diff --check`

Closes #219

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards the documented `country`, `timeout`, and `ignoreInvalidURLs` search fields on both `firecrawl_search` surfaces to `/v2/search`, so these options now work as documented. The `timeout` field also extends the outbound HTTP request by a 5-second margin so the transport doesn't cut off long searches. `categories` was already supported on `main`.

- Passes the fields through the strict search-only request allowlist.
- Adds regression tests for the published schema, both outbound request paths, and the transport margin.

<sup>Written for commit 3a38bdf8a2e9b60a43d0f84d688370e1cdb172c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

