### PR TITLE
fix(mcp): keep URL validation out of tool schemas

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1628,8 +1628,16 @@ function transformScrapeParams(
   return out;
 }
 
+// Keep URL validation at runtime without publishing `format: "uri"`, which
+// some MCP clients reject even though the value is valid JSON Schema.
+function runtimeUrl(schema = z.string().trim()) {
+  return schema.refine((value) => URL.canParse(value), {
+    message: 'Invalid URL',
+  });
+}
+
 const scrapeParamsSchema = z.object({
-  url: z.string().url(),
+  url: runtimeUrl(),
   formats: z
     .array(
       z.enum([
@@ -2163,7 +2171,7 @@ Enumerate URLs indexed under one website through Firecrawl without fetching each
 Returns matching URLs rather than page bodies. Retrieve one page with \`firecrawl_scrape\`; collect content across multiple pages with \`firecrawl_crawl\`.
 `,
   parameters: z.object({
-    url: z.string().url(),
+    url: runtimeUrl(),
     search: z.string().optional(),
     sitemap: z.enum(['include', 'skip', 'only']).optional(),
     includeSubdomains: z.boolean().optional(),
@@ -2479,7 +2487,7 @@ const feedbackIssueSchema = z
   );
 
 const valuableSourceSchema = z.object({
-  url: z.string().url(),
+  url: runtimeUrl(),
   reason: z.string().max(1000).optional(),
 });
 
@@ -2537,7 +2545,7 @@ Eligibility is limited to successful searches within the feedback age window. Th
       valuableSources: z
         .array(
           z.object({
-            url: z.string().url(),
+            url: runtimeUrl(),
             reason: z.string().max(1000).optional(),
           })
         )
@@ -2681,7 +2689,7 @@ Returns submission status, feedback ID, and accounting fields.
       valuableSources: z.array(valuableSourceSchema).max(50).optional(),
       missingContent: z.array(missingContentSchema).max(50).optional(),
       querySuggestions: z.string().max(2000).optional(),
-      url: z.string().url().optional(),
+      url: runtimeUrl().optional(),
       pageNumbers: z.array(z.number().int().positive()).max(100).optional(),
       metadata: z.record(z.string(), z.unknown()).optional(),
     }),
@@ -2940,7 +2948,7 @@ This call returns only a job ID, not the research result. Read the job with \`fi
 `,
   parameters: z.object({
     prompt: z.string().min(1).max(10000),
-    urls: z.array(z.string().url()).optional(),
+    urls: z.array(runtimeUrl()).optional(),
     schema: z.record(z.string(), z.any()).optional(),
   }),
   execute: async (args: unknown, { session, log }): Promise<string> => {
@@ -3006,7 +3014,7 @@ This acts on the live site, so actions such as form submission can create persis
   parameters: z
     .object({
       scrapeId: z.string().trim().min(1).optional(),
-      url: z.string().trim().url().optional(),
+      url: runtimeUrl(z.string().trim()).optional(),
       prompt: z.string().trim().min(1).optional(),
       code: z.string().trim().min(1).optional(),
       language: z.enum(['bash', 'python', 'node']).optional(),

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -212,6 +212,14 @@ async function startFakeFirecrawlApi() {
       return;
     }
 
+    if (req.method === 'POST' && req.url === '/v2/scrape') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({ data: { markdown: '# Example' }, success: true })
+      );
+      return;
+    }
+
     if (req.method === 'POST' && req.url === '/v2/monitor') {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(
@@ -829,8 +837,11 @@ class StdioMcpClient {
 }
 
 test('stdio transport initializes and lists Firecrawl tools', async (t) => {
+  const api = await startFakeFirecrawlApi();
+  t.after(() => api.close());
   const child = spawnServer({
     FIRECRAWL_API_KEY: 'fc-test',
+    FIRECRAWL_API_URL: api.url,
   });
   let stderr = '';
   child.stderr.on('data', (chunk) => {
@@ -853,6 +864,34 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   assert.ok(toolNames.includes('firecrawl_search'));
   assert.ok(toolNames.includes('firecrawl_parse'));
   assert.equal(toolNames.includes('firecrawl_extract'), false);
+
+  const toolsWithUriFormats = tools.tools
+    .filter((tool) =>
+      JSON.stringify(tool.inputSchema).includes('"format":"uri"')
+    )
+    .map((tool) => tool.name);
+  assert.deepEqual(
+    toolsWithUriFormats,
+    [],
+    `MCP tool schemas must not expose provider-incompatible URI formats: ${toolsWithUriFormats.join(', ')}`
+  );
+
+  const requestsBeforeInvalidUrl = api.requests.length;
+  await assert.rejects(
+    client.request('tools/call', {
+      arguments: { url: 'not-a-url' },
+      name: 'firecrawl_scrape',
+    }),
+    /-32602.*invalid url/i
+  );
+  assert.equal(api.requests.length, requestsBeforeInvalidUrl);
+
+  const trimmedUrl = await client.request('tools/call', {
+    arguments: { url: ' https://example.com/path ' },
+    name: 'firecrawl_scrape',
+  });
+  assert.notEqual(trimmedUrl.isError, true);
+  assert.equal(api.requests.at(-1).body.url, 'https://example.com/path');
 
   const deprecatedExtract = await client.request('tools/call', {
     // beforeValidate must intercept before the legacy required `urls` schema.


### PR DESCRIPTION
## Summary

- Fixes: Six advertised tools expose seven format: uri nodes, causing providers that do not accept that JSON Schema format to reject the tool definitions.
- Root cause: The Zod url() validator couples runtime URL validation to JSON Schema serialization, so FastMCP publishes format: uri even though the MCP handlers only need runtime validation.

Closes #196.

## Regression evidence

- Before: `pnpm run build >/dev/null && node --test --test-name-pattern='stdio transport initializes and lists Firecrawl tools' tests/mcp-smoke.test.mjs` exited `1`

- After: `pnpm run build >/dev/null && node --test --test-name-pattern='stdio transport initializes and lists Firecrawl tools' tests/mcp-smoke.test.mjs` exited `0`

## Verification

- `pnpm test`
- `pnpm lint`
- `pnpm exec tsc --noEmit`

## Scope

- 2 files changed, +54 / -7 lines

## AI assistance

- Codex was used to implement, test, and independently review this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps URL validation at runtime so MCP tool schemas no longer expose `format: uri`, which some providers reject. Six advertised tools previously exposed it because `z.string().url()` couples validation to schema serialization.

- Replaces `z.string().url()` with `runtimeUrl()` in all seven affected schema nodes; the helper validates with `URL.canParse()`, trims surrounding whitespace, and still blocks invalid URLs before they reach Firecrawl.
- Adds MCP smoke tests asserting that no tool schema contains `format: uri` and covering invalid and whitespace-padded URLs.
- Closes #196.

<sup>Written for commit 6eee2a33512c46503eac132b79327b3e0958edb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

