### PR TITLE
feat: add Agent Plugins 1.0 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Connect to the remote hosted server with no setup:
 https://mcp.firecrawl.dev/v2/mcp
 ```
 
+Install this endpoint as an [Agent Plugins 1.0](https://agent-plugins.org/specification) package across supported clients:
+
+```bash
+npx universal-agent-plugins add firecrawl
+```
+
 On the keyless free tier, `scrape`, `search`, and `parse` work without an API key (rate-limited). Other tools such as `crawl`, `map`, and `agent` still need a key.
 
 Prefer OAuth or an API key whenever the human can sign up. It unlocks the full tool set and higher limits.

--- a/agent-plugin/mcp.json
+++ b/agent-plugin/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "firecrawl": {
+      "type": "streamable-http",
+      "url": "https://mcp.firecrawl.dev/v2/mcp"
+    }
+  }
+}

--- a/agent-plugin/plugin.json
+++ b/agent-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "firecrawl",
+  "description": "Search, scrape, and parse public web content through Firecrawl's hosted MCP server.",
+  "author": {
+    "name": "Firecrawl",
+    "url": "https://www.firecrawl.dev/"
+  },
+  "homepage": "https://docs.firecrawl.dev/mcp-server",
+  "repository": "https://github.com/firecrawl/firecrawl-mcp-server",
+  "license": "MIT",
+  "keywords": ["firecrawl", "mcp", "research", "scraping", "search"]
+}


### PR DESCRIPTION
## What

- adds an Agent Plugins 1.0 package for the official hosted Firecrawl MCP endpoint
- keeps the package usable by compatible clients without this installer
- adds one optional README command using the reviewed `firecrawl` alias

## Verification

- Agent Plugins schemas pass
- the public `npx universal-agent-plugins@0.1.46 add firecrawl` command completed across isolated Codex, Cursor, Claude Code, Gemini CLI, and OpenCode profiles
- `info`, `update`, and `remove` passed for the same five targets; the interactive installer skipped incompatible installed clients before any change
- the package also passed isolated projection tests for Kiro, Cline, Windsurf, and VS Code
- the keyless endpoint completed MCP `initialize` and `tools/list`, returning `firecrawl_parse`, `firecrawl_scrape`, and `firecrawl_search`
- no tool was invoked, no credential was used, and no real agent profile was modified

This does not change Firecrawl runtime code, dependencies, endpoint behavior, or defaults.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Agent Plugins 1.0 package so users can install the hosted Firecrawl MCP endpoint directly with `npx universal-agent-plugins add firecrawl`.

- Adds `agent-plugin/plugin.json` with metadata and `agent-plugin/mcp.json` pointing at `https://mcp.firecrawl.dev/v2/mcp`.
- Adds the install command to the README as an optional setup path.
- Verified add, info, update, and remove across Codex, Cursor, Claude Code, Gemini CLI, and OpenCode without touching credentials or agent profiles.
- Runtime code, dependencies, endpoint behavior, and defaults are unchanged.

<sup>Written for commit f04c982028a56f0febcf6bb10e120a3dba519f02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

