### PR TITLE
docs: add FLUJO hosted client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ Replace `your-api-key` with your Firecrawl API key. If you don't have one yet, y
 
 After adding, refresh the MCP server list to see the new tools. The Composer Agent will automatically use Firecrawl MCP when appropriate, but you can explicitly request it by describing your web scraping needs. Access the Composer via Command+L (Mac), select "Agent" next to the submit button, and enter your query.
 
+### Running on FLUJO
+
+To connect [FLUJO](https://github.com/mario-andreschak/FLUJO) to the hosted MCP server:
+
+1. Open **Connected Apps** → **Connect App** → **I have connection details** → **At a remote URL**.
+2. Enter `https://mcp.firecrawl.dev/v2/mcp`, then select **Connect**.
+3. After the connection test passes, select **Update server**.
+
+The keyless free tier supports rate-limited `scrape`, `search`, and `parse`. Other tools require authentication as described in [Hosted MCP](#hosted-mcp-keyless-free-tier).
+
 ### Running on Windsurf
 
 Add this to your `./codeium/windsurf/model_config.json`:


### PR DESCRIPTION
Adds a short FLUJO setup section for the hosted MCP endpoint, alongside the existing client instructions. The section preserves the documented limits of the keyless tier.

Validated in FLUJO 3.45.2: the anonymous Streamable HTTP handshake passed, three tools were discovered, and the connection was saved through the UI. A real Tool Tester call to `firecrawl_search` with `limit: 1` returned `success: true` and one result.

This is a draft while a FLUJO UI issue is investigated: opening the `firecrawl_scrape` form twice triggered React error #185 before any scrape request. Reloading recovered the interface. Scrape and parse calls are not claimed as validated. No account, API key, OAuth login, or paid tool was used.

The patch changes only README.md (10 added lines); surrounding content is unchanged and `git diff --check` passes.

[Validation record and genuine screenshots](https://github.com/flujo-app/flujo-mcp-client-validation/tree/main/firecrawl).

Prepared and tested with Codex assistance for the FLUJO project.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Running on FLUJO" section to the README with setup steps for the hosted MCP endpoint, preserving the documented keyless free tier limits.

Validated in FLUJO 3.45.2: the anonymous Streamable HTTP handshake passed, three tools were discovered, and the connection saved through the UI. This is a draft because opening the `firecrawl_scrape` form twice triggers React error #185; scrape and parse calls are not claimed as validated.

<sup>Written for commit 20a9ec159c771ee5304a022927a0c336954e012d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



The reproduced client form failure and bounded investigation are now tracked in [FLUJO #517](https://github.com/mario-andreschak/FLUJO/issues/517). No source fix or successful scrape/parse validation is claimed.
